### PR TITLE
chore: Fixes typos

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,7 @@ Multiple Cucumber HTML Reporter
 
 Multiple Cucumber HTML Reporter is a reporting module for Cucumber to parse the JSON output to a beautiful report. The difference between all the other reporting modules on the market is that this module has:
 
-- a quick overview of all tested features and scenario's
+- a quick overview of all tested features and scenarios
 - a features overview that can hold multiple runs of the same feature / runs of the same feature on different browsers / devices
 - a features overview that can be searched / filtered / sorted
 - a feature(s) overview with metadata of the used browser(s) / devices

--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -182,7 +182,7 @@ function generateReport(options) {
 
     /**
      * Parse each scenario within a feature
-     * @param {object} feature a feature with all the scenario's in it
+     * @param {object} feature a feature with all the scenarios in it
      * @return {object} return the parsed feature
      * @private
      */

--- a/templates/components/scenarios-overview.chart.tmpl
+++ b/templates/components/scenarios-overview.chart.tmpl
@@ -1,5 +1,5 @@
 <div class="x_title">
-    <h2>Scenario's</h2>
+    <h2>Scenarios</h2>
     <ul class="nav navbar-right panel_toolbox">
         <li>
             <a class="collapse-link">

--- a/templates/style.css
+++ b/templates/style.css
@@ -373,7 +373,7 @@ ul.quick-list li i {
     color: #757679;
 }
 
-/* Features / Scenario's */
+/* Features / Scenarios */
 ul.panel_toolbox li .step {
     border-radius: 50%;
     color: #ffffff;

--- a/test/unit/data/collect-json/no-metadata.json
+++ b/test/unit/data/collect-json/no-metadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "  No elements have been founds\n  So the report should hold no scenario's and steps",
+    "description": "  No elements have been found\n  So the report should hold no scenarios and steps",
     "id": "no_elements.1494777183356",
     "keyword": "Feature",
     "line": 1,

--- a/test/unit/data/json/ambiguous_scenarios_specified_v1.json
+++ b/test/unit/data/json/ambiguous_scenarios_specified_v1.json
@@ -1,12 +1,12 @@
 [
   {
-    "description": "  The scenario's have been scripted twice\n  So the report should hold ambiguous steps",
+    "description": "  The scenarios have been scripted twice\n  So the report should hold ambiguous steps",
     "elements": [
       {
-        "id": "ambiguous-scenario's-specified-v1;ambiguous-johnny-wants-to-see-ambiguous-scenario's",
+        "id": "ambiguous-scenarios-specified-v1;ambiguous-johnny-wants-to-see-ambiguous-scenarios",
         "keyword": "Scenario",
         "line": 5,
-        "name": "Ambiguous Johnny wants to see ambiguous scenario's",
+        "name": "Ambiguous Johnny wants to see ambiguous scenarios",
         "steps": [
           {
             "arguments": [],
@@ -83,10 +83,10 @@
         "type": "scenario"
       }
     ],
-    "id": "ambiguous-scenario's-specified-v1",
+    "id": "ambiguous-scenarios-specified-v1",
     "keyword": "Feature",
     "line": 1,
-    "name": "Ambiguous scenario's specified V1",
+    "name": "Ambiguous scenarios specified V1",
     "tags": [],
     "uri": "/Users/wswebcreation/deTesters/protractor-cucumber-typescript-boilerplate/e2e-tests/features/ambiguous.feature",
     "metadata": {

--- a/test/unit/data/json/ambiguous_scenarios_specified_v2.json
+++ b/test/unit/data/json/ambiguous_scenarios_specified_v2.json
@@ -11,19 +11,19 @@
         "version": "16.04"
       }
     },
-    "description": "  The scenario's have been scripted twice\n  So the report should hold ambiguous steps",
+    "description": "  The scenarios have been scripted twice\n  So the report should hold ambiguous steps",
     "keyword": "Feature",
     "line": 1,
-    "name": "Ambiguous scenario's specified V2",
+    "name": "Ambiguous scenarios specified V2",
     "tags": [],
     "uri": "/Users/wswebcreation/deTesters/protractor-cucumber-typescript-boilerplate/e2e-tests/features/ambiguous.feature",
     "elements": [
       {
         "keyword": "Scenario",
         "line": 5,
-        "name": "Ambiguous Johnny wants to see ambiguous scenario's",
+        "name": "Ambiguous Johnny wants to see ambiguous scenarios",
         "tags": [],
-        "id": "ambiguous-scenario's-specified-v2;ambiguous-johnny-wants-to-see-ambiguous-scenario's",
+        "id": "ambiguous-scenarios-specified-v2;ambiguous-johnny-wants-to-see-ambiguous-scenarios",
         "steps": [
           {
             "arguments": [],
@@ -71,6 +71,6 @@
         ]
       }
     ],
-    "id": "ambiguous-scenario's-specified-v2"
+    "id": "ambiguous-scenarios-specified-v2"
   }
 ]

--- a/test/unit/data/json/ambiguous_scenarios_specified_v3.json
+++ b/test/unit/data/json/ambiguous_scenarios_specified_v3.json
@@ -11,19 +11,19 @@
         "version": "16.04"
       }
     },
-    "description": "  The scenario's have been scripted twice\n  So the report should hold ambiguous steps",
+    "description": "  The scenarios have been scripted twice\n  So the report should hold ambiguous steps",
     "keyword": "Feature",
-    "name": "Ambiguous scenario's specified V3",
+    "name": "Ambiguous scenarios specified V3",
     "line": 1,
-    "id": "ambiguous-scenario's-specified-v3",
+    "id": "ambiguous-scenarios-specified-v3",
     "tags": [],
     "uri": "e2e-tests/features/ambiguous.feature",
     "elements": [
       {
-        "id": "ambiguous-scenario's-specified-v3;ambiguous-johnny-wants-to-see-ambiguous-scenario's",
+        "id": "ambiguous-scenarios-specified-v3;ambiguous-johnny-wants-to-see-ambiguous-scenarios",
         "keyword": "Scenario",
         "line": 5,
-        "name": "Ambiguous Johnny wants to see ambiguous scenario's",
+        "name": "Ambiguous Johnny wants to see ambiguous scenarios",
         "tags": [],
         "type": "scenario",
         "steps": [

--- a/test/unit/data/json/failure_report_v1.json
+++ b/test/unit/data/json/failure_report_v1.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "    Failed scenario's should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
+    "description": "    Failed scenarios should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
     "elements": [
       {
         "id": "failure-report-v1;check-an-incorrect-to-do-amount",

--- a/test/unit/data/json/failure_report_v2.json
+++ b/test/unit/data/json/failure_report_v2.json
@@ -11,7 +11,7 @@
         "version": "10"
       }
     },
-    "description": "    Failed scenario's should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
+    "description": "    Failed scenarios should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
     "keyword": "Feature",
     "line": 2,
     "name": "Failure report V2",

--- a/test/unit/data/json/failure_report_v3.json
+++ b/test/unit/data/json/failure_report_v3.json
@@ -11,7 +11,7 @@
         "version": "10"
       }
     },
-    "description": "    Failed scenario's should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
+    "description": "    Failed scenarios should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
     "keyword": "Feature",
     "name": "Failure report V3",
     "line": 2,

--- a/test/unit/data/json/no_elements.json
+++ b/test/unit/data/json/no_elements.json
@@ -11,7 +11,7 @@
         "version": "not known"
       }
     },
-    "description": "  No elements have been founds\n  So the report should hold no scenario's and steps",
+    "description": "  No elements have been found\n  So the report should hold no scenarios and steps",
     "id": "no_elements.1494777183356",
     "keyword": "Feature",
     "line": 1,

--- a/test/unit/data/json/pending_scenarios_specified_v1.json
+++ b/test/unit/data/json/pending_scenarios_specified_v1.json
@@ -1,12 +1,12 @@
 [
   {
-    "description": "  The scenario's have scripted pending steps\n  So the report should hold pending steps",
+    "description": "  The scenarios have scripted pending steps\n  So the report should hold pending steps",
     "elements": [
       {
-        "id": "pending-scenario's-specified-v1;johnny-wants-to-see-pending-scenario's",
+        "id": "pending-scenarios-specified-v1;johnny-wants-to-see-pending-scenarios",
         "keyword": "Scenario",
         "line": 5,
-        "name": "Johnny wants to see pending scenario's",
+        "name": "Johnny wants to see pending scenarios",
         "steps": [
           {
             "arguments": [],
@@ -85,10 +85,10 @@
         "type": "scenario"
       }
     ],
-    "id": "pending-scenario's-specified-v1",
+    "id": "pending-scenarios-specified-v1",
     "keyword": "Feature",
     "line": 1,
-    "name": "Pending scenario's specified V1",
+    "name": "Pending scenarios specified V1",
     "tags": [],
     "uri": "/Users/wswebcreation/deTesters/protractor-cucumber-typescript-boilerplate/e2e-tests/features/pending.feature",
     "metadata": {

--- a/test/unit/data/json/pending_scenarios_specified_v2.json
+++ b/test/unit/data/json/pending_scenarios_specified_v2.json
@@ -11,19 +11,19 @@
         "version": "7.1"
       }
     },
-    "description": "  The scenario's have scripted pending steps\n  So the report should hold pending steps",
+    "description": "  The scenarios have scripted pending steps\n  So the report should hold pending steps",
     "keyword": "Feature",
     "line": 1,
-    "name": "Pending scenario's specified V2",
+    "name": "Pending scenarios specified V2",
     "tags": [],
     "uri": "/Users/wswebcreation/deTesters/protractor-cucumber-typescript-boilerplate/e2e-tests/features/pending.feature",
     "elements": [
       {
         "keyword": "Scenario",
         "line": 5,
-        "name": "Johnny wants to see pending scenario's",
+        "name": "Johnny wants to see pending scenarios",
         "tags": [],
-        "id": "pending-scenario's-specified-v2;johnny-wants-to-see-pending-scenario's",
+        "id": "pending-scenarios-specified-v2;johnny-wants-to-see-pending-scenarios",
         "steps": [
           {
             "arguments": [],
@@ -76,6 +76,6 @@
         ]
       }
     ],
-    "id": "pending-scenario's-specified-v2"
+    "id": "pending-scenarios-specified-v2"
   }
 ]

--- a/test/unit/data/json/pending_scenarios_specified_v3.json
+++ b/test/unit/data/json/pending_scenarios_specified_v3.json
@@ -11,19 +11,19 @@
         "version": "7.1"
       }
     },
-    "description": "  The scenario's have scripted pending steps\n  So the report should hold pending steps",
+    "description": "  The scenarios have scripted pending steps\n  So the report should hold pending steps",
     "keyword": "Feature",
-    "name": "Pending scenario's specified V3",
+    "name": "Pending scenarios specified V3",
     "line": 1,
-    "id": "pending-scenario's-specified-v3",
+    "id": "pending-scenarios-specified-v3",
     "tags": [],
     "uri": "e2e-tests/features/pending.feature",
     "elements": [
       {
-        "id": "pending-scenario's-specified-v3;johnny-wants-to-see-pending-scenario's",
+        "id": "pending-scenarios-specified-v3;johnny-wants-to-see-pending-scenarios",
         "keyword": "Scenario",
         "line": 5,
-        "name": "Johnny wants to see pending scenario's",
+        "name": "Johnny wants to see pending scenarios",
         "tags": [],
         "type": "scenario",
         "steps": [

--- a/test/unit/data/json/skipped_scenarios.json
+++ b/test/unit/data/json/skipped_scenarios.json
@@ -11,7 +11,7 @@
         "version": "10.12"
       }
     },
-    "description": "  The scenario's have been skipped\n  So the report should hold skipped scenario's",
+    "description": "  The scenarios have been skipped\n  So the report should hold skipped scenarios",
     "elements": [
       {
         "id": "angular-homepage;as-a-visitor-i-want-to-be-greeted",
@@ -275,7 +275,7 @@
     "id": "skipped_scenarios.1494823563764",
     "keyword": "Feature",
     "line": 1,
-    "name": "Skipped scenario's specified",
+    "name": "Skipped scenarios specified",
     "tags": [],
     "uri": "skipped_scenarios.1494823563764"
   }

--- a/test/unit/data/json/undefined_scenarios_specified_v1.json
+++ b/test/unit/data/json/undefined_scenarios_specified_v1.json
@@ -1,12 +1,12 @@
 [
   {
-    "description": "  No scenario's have scripted steps\n  So the report should hold undefined steps",
+    "description": "  No scenarios have scripted steps\n  So the report should hold undefined steps",
     "elements": [
       {
-        "id": "undefined-scenario's-specified-v1;timmy-wants-to-see-undefined-scenario's",
+        "id": "undefined-scenarios-specified-v1;timmy-wants-to-see-undefined-scenarios",
         "keyword": "Scenario",
         "line": 7,
-        "name": "Timmy wants to see undefined scenario's",
+        "name": "Timmy wants to see undefined scenarios",
         "steps": [
           {
             "arguments": [],
@@ -93,10 +93,10 @@
         "type": "scenario"
       }
     ],
-    "id": "undefined-scenario's-specified-v1",
+    "id": "undefined-scenarios-specified-v1",
     "keyword": "Feature",
     "line": 2,
-    "name": "Undefined scenario's specified V1",
+    "name": "Undefined scenarios specified V1",
     "tags": [
       {
         "name": "@undefined",

--- a/test/unit/data/json/undefined_scenarios_specified_v2.json
+++ b/test/unit/data/json/undefined_scenarios_specified_v2.json
@@ -11,10 +11,10 @@
         "version": "10.1.2"
       }
     },
-    "description": "  No scenario's have scripted steps\n  So the report should hold undefined steps",
+    "description": "  No scenarios have scripted steps\n  So the report should hold undefined steps",
     "keyword": "Feature",
     "line": 2,
-    "name": "Undefined scenario's specified V2",
+    "name": "Undefined scenarios specified V2",
     "tags": [
       {
         "line": 1,
@@ -26,7 +26,7 @@
       {
         "keyword": "Scenario",
         "line": 7,
-        "name": "Timmy wants to see undefined scenario's",
+        "name": "Timmy wants to see undefined scenarios",
         "tags": [
           {
             "line": 1,
@@ -45,7 +45,7 @@
             "name": "@nothing"
           }
         ],
-        "id": "undefined-scenario's-specified-v2;timmy-wants-to-see-undefined-scenario's",
+        "id": "undefined-scenarios-specified-v2;timmy-wants-to-see-undefined-scenarios",
         "steps": [
           {
             "arguments": [],
@@ -89,6 +89,6 @@
         ]
       }
     ],
-    "id": "undefined-scenario's-specified-v2"
+    "id": "undefined-scenarios-specified-v2"
   }
 ]

--- a/test/unit/data/json/undefined_scenarios_specified_v3.json
+++ b/test/unit/data/json/undefined_scenarios_specified_v3.json
@@ -11,11 +11,11 @@
         "version": "10.1.2"
       }
     },
-    "description": "  No scenario's have scripted steps\n  So the report should hold undefined steps",
+    "description": "  No scenarios have scripted steps\n  So the report should hold undefined steps",
     "keyword": "Feature",
-    "name": "Undefined scenario's specified V3",
+    "name": "Undefined scenarios specified V3",
     "line": 2,
-    "id": "undefined-scenario's-specified-v3",
+    "id": "undefined-scenarios-specified-v3",
     "tags": [
       {
         "name": "@undefined",
@@ -25,10 +25,10 @@
     "uri": "e2e-tests/features/undefined.feature",
     "elements": [
       {
-        "id": "undefined-scenario's-specified-v3;timmy-wants-to-see-undefined-scenario's",
+        "id": "undefined-scenarios-specified-v3;timmy-wants-to-see-undefined-scenarios",
         "keyword": "Scenario",
         "line": 7,
-        "name": "Timmy wants to see undefined scenario's",
+        "name": "Timmy wants to see undefined scenarios",
         "tags": [
           {
             "name": "@undefined",

--- a/test/unit/data/output/merged-output.json
+++ b/test/unit/data/output/merged-output.json
@@ -11,13 +11,13 @@
         "version": "16.04"
       }
     },
-    "description": "  The scenario's have been scripted twice\n  So the report should hold ambiguous steps",
+    "description": "  The scenarios have been scripted twice\n  So the report should hold ambiguous steps",
     "elements": [
       {
-        "id": "ambiguous-scenario's-specified-v1;ambiguous-johnny-wants-to-see-ambiguous-scenario's",
+        "id": "ambiguous-scenarios-specified-v1;ambiguous-johnny-wants-to-see-ambiguous-scenarios",
         "keyword": "Scenario",
         "line": 5,
-        "name": "Ambiguous Johnny wants to see ambiguous scenario's",
+        "name": "Ambiguous Johnny wants to see ambiguous scenarios",
         "steps": [
           {
             "arguments": [],
@@ -94,10 +94,10 @@
         "type": "scenario"
       }
     ],
-    "id": "ambiguous-scenario's-specified-v1",
+    "id": "ambiguous-scenarios-specified-v1",
     "keyword": "Feature",
     "line": 1,
-    "name": "Ambiguous scenario's specified V1",
+    "name": "Ambiguous scenarios specified V1",
     "tags": [],
     "uri": "/Users/wswebcreation/deTesters/protractor-cucumber-typescript-boilerplate/e2e-tests/features/ambiguous.feature"
   },
@@ -113,19 +113,19 @@
         "version": "16.04"
       }
     },
-    "description": "  The scenario's have been scripted twice\n  So the report should hold ambiguous steps",
+    "description": "  The scenarios have been scripted twice\n  So the report should hold ambiguous steps",
     "keyword": "Feature",
     "line": 1,
-    "name": "Ambiguous scenario's specified V2",
+    "name": "Ambiguous scenarios specified V2",
     "tags": [],
     "uri": "/Users/wswebcreation/deTesters/protractor-cucumber-typescript-boilerplate/e2e-tests/features/ambiguous.feature",
     "elements": [
       {
         "keyword": "Scenario",
         "line": 5,
-        "name": "Ambiguous Johnny wants to see ambiguous scenario's",
+        "name": "Ambiguous Johnny wants to see ambiguous scenarios",
         "tags": [],
-        "id": "ambiguous-scenario's-specified-v2;ambiguous-johnny-wants-to-see-ambiguous-scenario's",
+        "id": "ambiguous-scenarios-specified-v2;ambiguous-johnny-wants-to-see-ambiguous-scenarios",
         "steps": [
           {
             "arguments": [],
@@ -173,7 +173,7 @@
         ]
       }
     ],
-    "id": "ambiguous-scenario's-specified-v2"
+    "id": "ambiguous-scenarios-specified-v2"
   },
   {
     "metadata": {
@@ -187,19 +187,19 @@
         "version": "16.04"
       }
     },
-    "description": "  The scenario's have been scripted twice\n  So the report should hold ambiguous steps",
+    "description": "  The scenarios have been scripted twice\n  So the report should hold ambiguous steps",
     "keyword": "Feature",
-    "name": "Ambiguous scenario's specified V3",
+    "name": "Ambiguous scenarios specified V3",
     "line": 1,
-    "id": "ambiguous-scenario's-specified-v3",
+    "id": "ambiguous-scenarios-specified-v3",
     "tags": [],
     "uri": "e2e-tests/features/ambiguous.feature",
     "elements": [
       {
-        "id": "ambiguous-scenario's-specified-v3;ambiguous-johnny-wants-to-see-ambiguous-scenario's",
+        "id": "ambiguous-scenarios-specified-v3;ambiguous-johnny-wants-to-see-ambiguous-scenarios",
         "keyword": "Scenario",
         "line": 5,
-        "name": "Ambiguous Johnny wants to see ambiguous scenario's",
+        "name": "Ambiguous Johnny wants to see ambiguous scenarios",
         "tags": [],
         "type": "scenario",
         "steps": [
@@ -459,7 +459,7 @@
         "version": "10"
       }
     },
-    "description": "    Failed scenario's should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
+    "description": "    Failed scenarios should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
     "elements": [
       {
         "id": "failure-report-v1;check-an-incorrect-to-do-amount",
@@ -595,7 +595,7 @@
         "version": "10"
       }
     },
-    "description": "    Failed scenario's should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
+    "description": "    Failed scenarios should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
     "keyword": "Feature",
     "line": 2,
     "name": "Failure report V2",
@@ -707,7 +707,7 @@
         "version": "10"
       }
     },
-    "description": "    Failed scenario's should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
+    "description": "    Failed scenarios should have attached screenshots and stacktrace\n    So a reviewer can judge what went wrong",
     "keyword": "Feature",
     "name": "Failure report V3",
     "line": 2,
@@ -1792,7 +1792,7 @@
         "version": "not known"
       }
     },
-    "description": "  No elements have been founds\n  So the report should hold no scenario's and steps",
+    "description": "  No elements have been found\n  So the report should hold no scenarios and steps",
     "id": "no_elements.1494777183356",
     "keyword": "Feature",
     "line": 1,
@@ -1812,13 +1812,13 @@
         "version": "7.1"
       }
     },
-    "description": "  The scenario's have scripted pending steps\n  So the report should hold pending steps",
+    "description": "  The scenarios have scripted pending steps\n  So the report should hold pending steps",
     "elements": [
       {
-        "id": "pending-scenario's-specified-v1;johnny-wants-to-see-pending-scenario's",
+        "id": "pending-scenarios-specified-v1;johnny-wants-to-see-pending-scenarios",
         "keyword": "Scenario",
         "line": 5,
-        "name": "Johnny wants to see pending scenario's",
+        "name": "Johnny wants to see pending scenarios",
         "steps": [
           {
             "arguments": [],
@@ -1897,10 +1897,10 @@
         "type": "scenario"
       }
     ],
-    "id": "pending-scenario's-specified-v1",
+    "id": "pending-scenarios-specified-v1",
     "keyword": "Feature",
     "line": 1,
-    "name": "Pending scenario's specified V1",
+    "name": "Pending scenarios specified V1",
     "tags": [],
     "uri": "/Users/wswebcreation/deTesters/protractor-cucumber-typescript-boilerplate/e2e-tests/features/pending.feature"
   },
@@ -1916,19 +1916,19 @@
         "version": "7.1"
       }
     },
-    "description": "  The scenario's have scripted pending steps\n  So the report should hold pending steps",
+    "description": "  The scenarios have scripted pending steps\n  So the report should hold pending steps",
     "keyword": "Feature",
     "line": 1,
-    "name": "Pending scenario's specified V2",
+    "name": "Pending scenarios specified V2",
     "tags": [],
     "uri": "/Users/wswebcreation/deTesters/protractor-cucumber-typescript-boilerplate/e2e-tests/features/pending.feature",
     "elements": [
       {
         "keyword": "Scenario",
         "line": 5,
-        "name": "Johnny wants to see pending scenario's",
+        "name": "Johnny wants to see pending scenarios",
         "tags": [],
-        "id": "pending-scenario's-specified-v2;johnny-wants-to-see-pending-scenario's",
+        "id": "pending-scenarios-specified-v2;johnny-wants-to-see-pending-scenarios",
         "steps": [
           {
             "arguments": [],
@@ -1981,7 +1981,7 @@
         ]
       }
     ],
-    "id": "pending-scenario's-specified-v2"
+    "id": "pending-scenarios-specified-v2"
   },
   {
     "metadata": {
@@ -1995,19 +1995,19 @@
         "version": "7.1"
       }
     },
-    "description": "  The scenario's have scripted pending steps\n  So the report should hold pending steps",
+    "description": "  The scenarios have scripted pending steps\n  So the report should hold pending steps",
     "keyword": "Feature",
-    "name": "Pending scenario's specified V3",
+    "name": "Pending scenarios specified V3",
     "line": 1,
-    "id": "pending-scenario's-specified-v3",
+    "id": "pending-scenarios-specified-v3",
     "tags": [],
     "uri": "e2e-tests/features/pending.feature",
     "elements": [
       {
-        "id": "pending-scenario's-specified-v3;johnny-wants-to-see-pending-scenario's",
+        "id": "pending-scenarios-specified-v3;johnny-wants-to-see-pending-scenarios",
         "keyword": "Scenario",
         "line": 5,
-        "name": "Johnny wants to see pending scenario's",
+        "name": "Johnny wants to see pending scenarios",
         "tags": [],
         "type": "scenario",
         "steps": [
@@ -2074,7 +2074,7 @@
         "version": "10.12"
       }
     },
-    "description": "  The scenario's have been skipped\n  So the report should hold skipped scenario's",
+    "description": "  The scenarios have been skipped\n  So the report should hold skipped scenarios",
     "elements": [
       {
         "id": "angular-homepage;as-a-visitor-i-want-to-be-greeted",
@@ -2338,7 +2338,7 @@
     "id": "skipped_scenarios.1494823563764",
     "keyword": "Feature",
     "line": 1,
-    "name": "Skipped scenario's specified",
+    "name": "Skipped scenarios specified",
     "tags": [],
     "uri": "skipped_scenarios.1494823563764"
   },
@@ -2354,13 +2354,13 @@
         "version": "10.1.2"
       }
     },
-    "description": "  No scenario's have scripted steps\n  So the report should hold undefined steps",
+    "description": "  No scenarios have scripted steps\n  So the report should hold undefined steps",
     "elements": [
       {
-        "id": "undefined-scenario's-specified-v1;timmy-wants-to-see-undefined-scenario's",
+        "id": "undefined-scenarios-specified-v1;timmy-wants-to-see-undefined-scenarios",
         "keyword": "Scenario",
         "line": 7,
-        "name": "Timmy wants to see undefined scenario's",
+        "name": "Timmy wants to see undefined scenarios",
         "steps": [
           {
             "arguments": [],
@@ -2447,10 +2447,10 @@
         "type": "scenario"
       }
     ],
-    "id": "undefined-scenario's-specified-v1",
+    "id": "undefined-scenarios-specified-v1",
     "keyword": "Feature",
     "line": 2,
-    "name": "Undefined scenario's specified V1",
+    "name": "Undefined scenarios specified V1",
     "tags": [
       {
         "name": "@undefined",
@@ -2471,10 +2471,10 @@
         "version": "10.1.2"
       }
     },
-    "description": "  No scenario's have scripted steps\n  So the report should hold undefined steps",
+    "description": "  No scenarios have scripted steps\n  So the report should hold undefined steps",
     "keyword": "Feature",
     "line": 2,
-    "name": "Undefined scenario's specified V2",
+    "name": "Undefined scenarios specified V2",
     "tags": [
       {
         "line": 1,
@@ -2486,7 +2486,7 @@
       {
         "keyword": "Scenario",
         "line": 7,
-        "name": "Timmy wants to see undefined scenario's",
+        "name": "Timmy wants to see undefined scenarios",
         "tags": [
           {
             "line": 1,
@@ -2505,7 +2505,7 @@
             "name": "@nothing"
           }
         ],
-        "id": "undefined-scenario's-specified-v2;timmy-wants-to-see-undefined-scenario's",
+        "id": "undefined-scenarios-specified-v2;timmy-wants-to-see-undefined-scenarios",
         "steps": [
           {
             "arguments": [],
@@ -2549,7 +2549,7 @@
         ]
       }
     ],
-    "id": "undefined-scenario's-specified-v2"
+    "id": "undefined-scenarios-specified-v2"
   },
   {
     "metadata": {
@@ -2563,11 +2563,11 @@
         "version": "10.1.2"
       }
     },
-    "description": "  No scenario's have scripted steps\n  So the report should hold undefined steps",
+    "description": "  No scenarios have scripted steps\n  So the report should hold undefined steps",
     "keyword": "Feature",
-    "name": "Undefined scenario's specified V3",
+    "name": "Undefined scenarios specified V3",
     "line": 2,
-    "id": "undefined-scenario's-specified-v3",
+    "id": "undefined-scenarios-specified-v3",
     "tags": [
       {
         "name": "@undefined",
@@ -2577,10 +2577,10 @@
     "uri": "e2e-tests/features/undefined.feature",
     "elements": [
       {
-        "id": "undefined-scenario's-specified-v3;timmy-wants-to-see-undefined-scenario's",
+        "id": "undefined-scenarios-specified-v3;timmy-wants-to-see-undefined-scenarios",
         "keyword": "Scenario",
         "line": 7,
-        "name": "Timmy wants to see undefined scenario's",
+        "name": "Timmy wants to see undefined scenarios",
         "tags": [
           {
             "name": "@undefined",

--- a/test/unit/data/output/provided-metadata.json
+++ b/test/unit/data/output/provided-metadata.json
@@ -11,7 +11,7 @@
         "version": "16.04"
       }
     },
-    "description": "  No elements have been founds\n  So the report should hold no scenario's and steps",
+    "description": "  No elements have been found\n  So the report should hold no scenarios and steps",
     "id": "no_elements.1494777183356",
     "keyword": "Feature",
     "line": 1,


### PR DESCRIPTION
A small set of changes to use the correct plural form of 'scenario' in the generated reports and tests.  Also swaps 'No elements have been founds' for 'No elements have been found'.