### PR TITLE
fix: correctly show the skipped features on the report home page

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -72,9 +72,11 @@ function generateReport(options) {
             ambiguous: 0,
             failed: 0,
             passed: 0,
+            skipped: 0,
             total: 0,
             ambiguousPercentage: 0,
             failedPercentage: 0,
+            skippedPercentage: 0,
             passedPercentage: 0
         },
         reportName: reportName,
@@ -95,6 +97,7 @@ function generateReport(options) {
     // Percentages
     suite.featureCount.ambiguousPercentage = _calculatePercentage(suite.featureCount.ambiguous, suite.featureCount.total);
     suite.featureCount.failedPercentage = _calculatePercentage(suite.featureCount.failed, suite.featureCount.total);
+    suite.featureCount.skippedPercentage = _calculatePercentage(suite.featureCount.skipped, suite.featureCount.total);
     suite.featureCount.passedPercentage = _calculatePercentage(suite.featureCount.passed, suite.featureCount.total);
 
     /**
@@ -151,6 +154,7 @@ function generateReport(options) {
             feature.time = 0;
             feature.isFailed = false;
             feature.isAmbiguous = false;
+            feature.isSkipped = false;
             suite.featureCount.total++;
             feature.id = `${uuid()}.${feature.id}`.replace(/[^a-zA-Z0-9-_]/g, '-');
             feature.app = 0;
@@ -168,6 +172,9 @@ function generateReport(options) {
             } else if (feature.isAmbiguous) {
                 suite.featureCount.ambiguous++;
                 feature.ambiguous++;
+            } else if (feature.isSkipped) {
+                feature.skipped++;
+                suite.featureCount.skipped++;
             } else {
                 feature.passed++;
                 suite.featureCount.passed++;
@@ -265,6 +272,8 @@ function generateReport(options) {
             }
         });
 
+        feature.isSkipped = feature.scenarios.total === feature.scenarios.skipped;
+
         return feature;
     }
 
@@ -325,7 +334,7 @@ function generateReport(options) {
             if (step.result.status === RESULT_STATUS.ambiguous) {
                 return scenario.ambiguous++;
             }
-
+           
             scenario.skipped++;
         });
 

--- a/templates/components/features-overview.chart.tmpl
+++ b/templates/components/features-overview.chart.tmpl
@@ -49,6 +49,18 @@
                         </td>
                         <td class="percentage"><%= suite.featureCount.failedPercentage %> %</td>
                     </tr>
+                    <%if(suite.featureCount.skipped > 0){%>
+                    <tr>
+                        <td>
+                            <p data-toggle="tooltip" data-placement="left"
+                               title="Scenario skipped">
+                                <i class="fa fa-arrow-circle-right skipped-color"></i>
+                                Skipped
+                            </p>
+                        </td>
+                        <td class="percentage"><%= suite.featureCount.skippedPercentage %> %</td>
+                    </tr>
+                    <%}%>
                     <%if(suite.featureCount.ambiguous > 0){%>
                     <tr>
                         <td>

--- a/templates/components/features-overview.tmpl
+++ b/templates/components/features-overview.tmpl
@@ -75,6 +75,9 @@
                             <% if (feature.isFailed) { %>
                             <% status = 'Failed'; %>
                             <% statusIcon = 'exclamation-circle failed-color'; %>
+                            <% } else if (feature.isSkipped) { %>
+                            <% status = 'Skipped'; %>
+                            <% statusIcon = 'arrow-circle-right skipped-color'; %>
                             <% } else if (feature.isAmbiguous) { %>
                             <% status = 'Ambiguous'; %>
                             <% statusIcon = 'flash ambiguous-color'; %>

--- a/templates/features-overview.index.tmpl
+++ b/templates/features-overview.index.tmpl
@@ -101,17 +101,21 @@
                         labels: [
                             "Passed",
                             "Failed",
+                            "Skipped",
                             "Ambiguous"
                         ],
                         datasets: [{
                             data: [
                                 <%= suite.featureCount.passedPercentage %>,
                                 <%= suite.featureCount.failedPercentage %>,
-                                <%= suite.featureCount.ambiguousPercentage %>],
+                                <%= suite.featureCount.skippedPercentage %>,
+                                <%= suite.featureCount.ambiguousPercentage %>
+                            ],
                             backgroundColor: [
                                 "#26B99A",
                                 "#E74C3C",
-                                "#b73122"
+                                "#3498DB",
+                                "#b73122"                                
                             ]
                         }]
                     },


### PR DESCRIPTION
This is the PR for #20.

I've updated the features chart on the home page to include skipped:

![image](https://user-images.githubusercontent.com/2734580/34303297-a243e2e4-e72c-11e7-80fc-1e5df0701a57.png)


And updated the status column on the features table:

![image](https://user-images.githubusercontent.com/2734580/34303216-56ed69e6-e72c-11e7-8271-ca4f785893e6.png)


Today is my last day in the office until 3rd January.  If there's any comments / changes, I'll pick them up after Christmas.
