### PR TITLE
fix: show edge icon for tests run with microsoft edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "main": "lib/generate-report.js",
   "scripts": {
     "test": "node ./test/test.js",
+    "unit.test": "jasmine JASMINE_CONFIG_PATH=test/unit/jasmine.json",
     "unit.test.coverage": "JASMINE_CONFIG_PATH=test/unit/jasmine.json istanbul cover jasmine",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },

--- a/templates/components/feature-metadata-overview.tmpl
+++ b/templates/components/feature-metadata-overview.tmpl
@@ -69,8 +69,10 @@
                 <span class="meta-data-title">Browser</span>
                 <span class="meta-data-data">
                     <% var browserIcon; %>
-                    <% if (['firefox', 'safari', 'chrome', 'edge'].indexOf(metadata.browser.name.toLowerCase()) > -1) { %>
+                    <% if (['firefox', 'safari', 'chrome'].indexOf(metadata.browser.name.toLowerCase()) > -1) { %>
                     <% browserIcon = metadata.browser.name.toLowerCase(); %>
+                    <% } else if (metadata.browser.name.toLowerCase() === 'edge' || metadata.browser.name.toLowerCase() === 'microsoftedge'){ %>
+                    <% browserIcon= "edge"; %>
                     <% } else if (metadata.browser.name.toLowerCase() === 'internet explorer'){ %>
                     <% browserIcon= "internet-explorer"; %>
                     <% } else { %>

--- a/templates/components/features-overview.tmpl
+++ b/templates/components/features-overview.tmpl
@@ -143,8 +143,10 @@
                         <td>
                             <% if(feature.metadata.browser) { %>
                             <% var browserIcon; %>
-                            <% if (['firefox', 'safari', 'chrome', 'edge'].indexOf(feature.metadata.browser.name.toLowerCase()) > -1) { %>
+                            <% if (['firefox', 'safari', 'chrome'].indexOf(feature.metadata.browser.name.toLowerCase()) > -1) { %>
                             <% browserIcon = feature.metadata.browser.name.toLowerCase(); %>
+                            <% } else if (feature.metadata.browser.name.toLowerCase() === 'edge' || feature.metadata.browser.name.toLowerCase() === 'microsoftedge'){ %>
+                            <% browserIcon= "edge"; %>
                             <% } else if (feature.metadata.browser.name.toLowerCase() === 'internet explorer'){ %>
                             <% browserIcon= "internet-explorer"; %>
                             <% } else { %>

--- a/test/unit/data/json/happy_flow_v3.json
+++ b/test/unit/data/json/happy_flow_v3.json
@@ -2,7 +2,7 @@
   {
     "metadata": {
       "browser": {
-        "name": "Edge",
+        "name": "microsoftedge",
         "version": "14"
       },
       "device": "Virtual Machine",

--- a/test/unit/data/output/merged-output.json
+++ b/test/unit/data/output/merged-output.json
@@ -1644,7 +1644,7 @@
   {
     "metadata": {
       "browser": {
-        "name": "Edge",
+        "name": "microsoftedge",
         "version": "14"
       },
       "device": "Virtual Machine",


### PR DESCRIPTION
This is the fix for #25.

I've updated the templates, and one of the json result files to test that it renders correctly with `npm run test`

As you can see it renders correctly now:

![image](https://user-images.githubusercontent.com/2734580/35613347-b9e5d2da-0663-11e8-9b6a-5aa854810dbe.png)
