### PR TITLE
fix of attaching multiple json and text attachments to the same step

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -290,16 +290,12 @@ function generateReport(options) {
 
                 step.embeddings.forEach((embedding, embeddingIndex) => {
                     /* istanbul ignore else */
-                    if (embedding.mime_type === 'text/plain' || (embedding.media && embedding.media.type === 'text/plain')) {
-                        if (!step.text) {
-                            try {
-                                step.text = JSON.parse(embedding.data)
-                            } catch (error) {
-                                step.text = _isBase64(embedding.data) ? Base64.decode(embedding.data) : embedding.data;
-                            }
-                        } else {
-                            step.text = step.text.concat(`<br>  ${_isBase64(embedding.data) ? Base64.decode(embedding.data) : embedding.data}`);
-                        }
+		    if (embedding.mime_type === 'application/json' || embedding.media && embedding.media.type === 'application/json') {
+			step.text = (step.text ? step.text : []).concat([JSON.parse(embedding.data)]);
+	            } else if (embedding.mime_type === 'text/plain' || (embedding.media && embedding.media.type === 'text/plain')) {
+		        step.text = (step.text ? step.text : []).concat([
+				_isBase64(embedding.data) ? Base64.decode(embedding.data)
+							  : embedding.data]);
                     } else if (embedding.mime_type === 'image/png' || (embedding.media && embedding.media.type === 'image/png')) {
                         step.image = 'data:image/png;base64,' + embedding.data;
                         step.embeddings[embeddingIndex] = {};

--- a/test/unit/data/custom-metadata-json/multiple_different_attachements.json
+++ b/test/unit/data/custom-metadata-json/multiple_different_attachements.json
@@ -1,0 +1,96 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "Multiple json and plain text attachments",
+    "line": 1,
+    "id": "google.com",
+    "tags": [],
+    "uri": "features/google.feature",
+    "elements": [
+      {
+        "id": "google.com;i-open-google",
+        "keyword": "Scenario",
+        "line": 2,
+        "name": "I open google",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "Before",
+            "hidden": true,
+            "match": {
+              "location": "src/steps.js:59"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 616
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 3,
+            "name": "I open url 'https://www.google.com/?hl=en'",
+            "match": {
+              "location": "src/steps.js:322"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 1193
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 4,
+            "name": "I see input with value 'Google Search'",
+            "match": {
+              "location": "src/steps.js:418"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 1214
+            },
+            "embeddings": [
+              {
+                "data": "{\"some\":\"json\"}",
+                "media": {
+                  "type": "application/json"
+                }
+              },
+              {
+                "data": "{\"other\":\"json\"}",
+                "media": {
+                  "type": "application/json"
+                }
+              },
+	      {
+		"data": "Some plain text message",
+                "media": {
+                  "type": "text/plain"
+                }
+	      },
+	      {
+		"data": "{\"yet another json\":5}",
+		"media": {
+	          "type": "application/json"
+		}
+              }
+            ]
+          },
+          {
+            "keyword": "After",
+            "hidden": true,
+            "match": {
+              "location": "src/steps.js:629"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 295
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This fixes having multiple attachments for a single step (if they are not all plain texts)

I also added mime type check for 'application/json' because it is officially recomended way of attaching jsons from cucumber-js, as desribed [here](https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/attachments.md)

I made **step.text** an array because it is the most obvious way to have attachments of different types (plain text and json) displayed together.

Added test json that was used to reproduce the problem as 
`test/unit/data/custom-metadata-json/multiple_different_attachements.json`