### PR TITLE
Add save sort state to columns under Features overview

### DIFF
--- a/templates/features-overview.index.tmpl
+++ b/templates/features-overview.index.tmpl
@@ -87,7 +87,8 @@
             $(document).ready(function () {
                 $('#features-table').dataTable({
                     "order": [[0, "asc"]],
-                    "lengthMenu": [[50, 100, 150, -1], [50, 100, 150, "All"]]
+                    "lengthMenu": [[50, 100, 150, -1], [50, 100, 150, "All"]],
+                    "stateSave": true
                 });
 
                 var featureOptions = {


### PR DESCRIPTION
Adds a save state to the columns under Features overview that will remember your sort order when you reload a page, or come back to the page after visiting a sub-page.

This is especially useful when you want to order by failed tests. You then would be able to sort by failed, click into a feature, look at what's wrong, navigate back, and click the next failed feature without needing to reapply the sort order.

https://datatables.net/examples/basic_init/state_save.html