### PR TITLE
Add support for multiple screenshots in scenario steps

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -313,7 +313,7 @@ function generateReport(options) {
               embedding.data
             ]);
           } else if (embedding.mime_type === 'image/png' || (embedding.media && embedding.media.type === 'image/png')) {
-            step.image = 'data:image/png;base64,' + embedding.data;
+            step.image = (step.image ? step.image : []).concat(['data:image/png;base64,' + embedding.data]);
             step.embeddings[embeddingIndex] = {};
           } else  {
             let embeddingtype = "text/plain";

--- a/templates/components/scenarios.tmpl
+++ b/templates/components/scenarios.tmpl
@@ -182,9 +182,11 @@
 
                       <% if (step.image) { %>
                         <div id="info<%= scenarioIndex %><%= stepIndex %>-image" class="scenario-step-collapse collapse">
-                          <a class="screenshot" href="<%= step.image %>" target="_blank">
-                    <img class="screenshot" src="<%= step.image %>"/>
-                </a>
+                          <% for( var i = 0; i < step.image.length; i++ ) { %>
+                            <a class="screenshot" href="<%= step.image[i] %>" target="_blank">
+                                <img class="screenshot" src="<%= step.image[i] %>"/>
+                            </a>
+                          <% } %>
                         </div>
                         <% } %>
 


### PR DESCRIPTION
Cucumber allows saving of multiple images, but the report currently only displays the last image that was attached.

Updated the report to show all images attached to a step.

**Note:** I advise updating the css to better accommodate multiple images. Currently, small images will stretch to the width of the largest image - making them looked stretched,  and it's hard to tell where an image ends and another stops. In the screenshots below, you'll see how it looks with my custom css that I feel best displays the images. I'll gladly give you the css if you're wanting to copy and use it.

![report-screenshots-step](https://user-images.githubusercontent.com/36996748/39221974-9bf05cd6-47ff-11e8-9dc6-46f329475d3d.png)

![report-screenshots-after](https://user-images.githubusercontent.com/36996748/39221978-9fca3ef8-47ff-11e8-9cc4-bafe4de280fb.png)
