### PR TITLE
allow empty json reports instead of failing

### DIFF
--- a/lib/collect-jsons.js
+++ b/lib/collect-jsons.js
@@ -19,26 +19,30 @@ module.exports = function collectJSONS(options) {
         throw new Error(`No JSON files found in '${options.jsonDir}'. NO REPORT CAN BE CREATED!`);
     }
 
-    files.map(file => jsonFile.readFileSync(file).map(json => {
-        if(options.metadata && !json.metadata){
-            json.metadata = options.metadata;
-        } else {
-            json = Object.assign({
-                "metadata": {
-                    "browser": {
-                        "name": "not known",
-                        "version": "not known"
-                    },
-                    "device": "not known",
-                    "platform": {
-                        "name": "not known",
-                        "version": "not known"
+    files.map(file => {
+        // Cucumber json can be  empty, it's likely being created by another process (#47)
+        const data = fs.readFileSync(file).toString() || "[]";
+        JSON.parse(data).map(json => {
+            if (options.metadata && !json.metadata) {
+                json.metadata = options.metadata;
+            } else {
+                json = Object.assign({
+                    "metadata": {
+                        "browser": {
+                            "name": "not known",
+                            "version": "not known"
+                        },
+                        "device": "not known",
+                        "platform": {
+                            "name": "not known",
+                            "version": "not known"
+                        }
                     }
-                }
-            }, json);
-        }
-        jsonOutput.push(json)
-    }));
+                }, json);
+            }
+            jsonOutput.push(json)
+        });
+    });
 
     if (options.saveCollectedJSON) {
         const file = path.resolve(options.reportPath, 'merged-output.json');


### PR DESCRIPTION
Fixes #47 

Specifically check for empty json and not ignoring *all* invalid json, because in some cases, you just want to see something is wrong.