### PR TITLE
Support for unescaped text/html embeds

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -307,14 +307,19 @@ function generateReport(options) {
           /* istanbul ignore else */
           if (embedding.mime_type === 'application/json' || embedding.media && embedding.media.type === 'application/json') {
             step.text = (step.text ? step.text : []).concat([JSON.parse(embedding.data)]);
+          } else if (embedding.mime_type === 'text/html' || (embedding.media && embedding.media.type === 'text/html')) {
+              step.html = (step.html ? step.html : []).concat([
+                  _isBase64(embedding.data) ? Base64.decode(embedding.data) :
+                      embedding.data
+              ]);
           } else if (embedding.mime_type === 'text/plain' || (embedding.media && embedding.media.type === 'text/plain')) {
             step.text = (step.text ? step.text : []).concat([
               _isBase64(embedding.data) ? Base64.decode(embedding.data) :
               embedding.data
             ]);
           } else if (embedding.mime_type === 'image/png' || (embedding.media && embedding.media.type === 'image/png')) {
-            step.image = (step.image ? step.image : []).concat(['data:image/png;base64,' + embedding.data]);
-            step.embeddings[embeddingIndex] = {};
+              step.image = (step.image ? step.image : []).concat(['data:image/png;base64,' + embedding.data]);
+              step.embeddings[embeddingIndex] = {};
           } else  {
             let embeddingtype = "text/plain";
             if ( embedding.mime_type ) {

--- a/templates/components/scenarios.tmpl
+++ b/templates/components/scenarios.tmpl
@@ -146,21 +146,25 @@
                                             <a href="#info<%= scenarioIndex %><%= stepIndex %>-text" data-toggle="collapse">+ Show Info</a>
                                             <% } %>
 
-                                              <% if (step.image) { %>
-                                                <a href="#info<%= scenarioIndex %><%= stepIndex %>-image" data-toggle="collapse">Screenshot +</a>
-                                                <% } %>
+                                             <% if (step.html) { %>
+                                            <a href="#info<%= scenarioIndex %><%= stepIndex %>-html" data-toggle="collapse">+ Show Info</a>
+                                            <% } %>
 
-                                                  <% if (!_.isEmpty(step.attachments)) { %>
-                                                    <span>[</span>
-                                                    <% _.each(step.attachments, function(attachment, attachmentIndex) { %>
-                                                      <a href="#info<%= scenarioIndex %><%= stepIndex %>-attachment<%= attachmentIndex %>" data-toggle="collapse">Attachment</a>
-                                                      <% if ( attachmentIndex < ( _.size(step.attachments) - 1 ) ) { %>
-                                                        <span>  ,</span>
-                                                        <% } %>
-                                                          <% }); %>
-                                                            <span>]</span>
+                                                  <% if (step.image) { %>
+                                                    <a href="#info<%= scenarioIndex %><%= stepIndex %>-image" data-toggle="collapse">Screenshot +</a>
+                                                    <% } %>
+
+                                                      <% if (!_.isEmpty(step.attachments)) { %>
+                                                        <span>[</span>
+                                                        <% _.each(step.attachments, function(attachment, attachmentIndex) { %>
+                                                          <a href="#info<%= scenarioIndex %><%= stepIndex %>-attachment<%= attachmentIndex %>" data-toggle="collapse">Attachment</a>
+                                                          <% if ( attachmentIndex < ( _.size(step.attachments) - 1 ) ) { %>
+                                                            <span>  ,</span>
                                                             <% } %>
-                                                              <% } %>
+                                                              <% }); %>
+                                                                <span>]</span>
+                                                                <% } %>
+                                                                  <% } %>
             </div>
 
             <% if(step.result) { %>
@@ -179,6 +183,12 @@
 <% } %></pre>
                     </div>
                     <% } %>
+
+                     <% if (step.html) { %>
+                                        <div id="info<%= scenarioIndex %><%= stepIndex %>-html" class="scenario-step-collapse collapse">
+                                          <div class=info><%= step.html.join('<br/>') %></div>
+                                        </div>
+                                        <% } %>
 
                       <% if (step.image) { %>
                         <div id="info<%= scenarioIndex %><%= stepIndex %>-image" class="scenario-step-collapse collapse">

--- a/test/unit/data/embedded-array-json/embedded_success_v1.json
+++ b/test/unit/data/embedded-array-json/embedded_success_v1.json
@@ -294,12 +294,35 @@
           {
             "arguments": [],
             "keyword": "And ",
+            "name": "I should have an HTML",
+            "result": {
+              "status": "passed",
+              "duration": 848834826
+            },
+            "embeddings": [
+              {
+                "data": "<H1>This is an HTML</H1><div><ul><li>1st</li><li>2nd</li></ul></div>",
+                "mime_type": "text/html"
+              },
+              {
+                "data": "<H1>This is a 2nd HTML</H1><div><ul><li>3rd</li><li>4th</li></ul></div>",
+                "mime_type": "text/html"
+              }
+            ],
+            "line": 21,
+            "match": {
+              "location": "/Users/wswebcreation/deTesters/protractor-cucumber-typescript-boilerplate/node_modules/cucumber-tsflow/src/BindingDecorator.ts:163"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
             "name": "the last todo should hold \"write a protractor test\"",
             "result": {
               "status": "passed",
               "duration": 48083312
             },
-            "line": 21,
+            "line": 22,
             "match": {
               "location": "/Users/wswebcreation/deTesters/protractor-cucumber-typescript-boilerplate/node_modules/cucumber-tsflow/src/BindingDecorator.ts:163"
             }


### PR DESCRIPTION
This pull request allows the user to embed the `text/html` mime type, and have the embed data displayed, unescaped, in the scenario report.

The commit consists of 3 main changes:

1. Add a `text/html` mime_type handler to the if structure in `_parseSteps`. I just collects the data into a `.html` property on the step.
2. Add a relevant template structure to handle the `.html` property. It joins multiple attachments into a single HTML block, separated by a `<br/>` element.
3. Add an html embed step to the test data.