### PR TITLE
Show html embeds for hidden steps

### DIFF
--- a/templates/components/scenarios.tmpl
+++ b/templates/components/scenarios.tmpl
@@ -79,7 +79,7 @@
       <div class="x_content" style="display: none;">
         <% _.each(scenario.steps, function(step, stepIndex) { %>
 
-          <% if(!step.hidden || step.image || step.text || step.attachment || step.result.status === 'failed') { %>
+          <% if(!step.hidden || step.image || step.text || step.html || step.attachment || step.result.status === 'failed') { %>
             <div class="scenario-step-container">
               <% if(step.result) { %>
                 <% if(step.result.status === 'passed') { %>


### PR DESCRIPTION
Update template condition to not suppress output for hidden steps w/ html embed

Fixes an issue I created in #59.