### PR TITLE
Made collect-jsons.js return an actual empty array instead of string.

### DIFF
--- a/lib/collect-jsons.js
+++ b/lib/collect-jsons.js
@@ -41,16 +41,16 @@ module.exports = function collectJSONS(options) {
                 jsonOutput.push(json)
             });
         });
-    
+
         if (options.saveCollectedJSON) {
             const file = path.resolve(options.reportPath, 'merged-output.json');
             fs.ensureDirSync(options.reportPath);
             jsonFile.writeFileSync(file, jsonOutput, {spaces: 2});
         }
-    
+
         return jsonOutput;
     }
 
     console.log(chalk.yellow(`WARNING: No JSON files found in '${options.jsonDir}'. NO REPORT CAN BE CREATED!`));
-    return "[]";
+    return [];
 };

--- a/test/unit/collect-jsons.spec.js
+++ b/test/unit/collect-jsons.spec.js
@@ -58,5 +58,14 @@ describe('collect-jsons.js', () => {
             });
             expect(console.log).toHaveBeenCalledWith(chalk.yellow(`WARNING: No JSON files found in './test/unit/data/no-jsons'. NO REPORT CAN BE CREATED!`))
         });
+
+        it('should return an empty array when no json files could be found', () => {
+            const results = collectJSONS({
+                jsonDir: './test/unit/data/no-jsons',
+                reportPath: reportPath
+            });
+            expect(Array.isArray(results)).toBeTruthy();
+            expect(results.length).toBe(0);
+        });
     });
 });


### PR DESCRIPTION
Also, added a unit test for safe measures.