### PR TITLE
Add OpenGraph HTML metadata in the test report.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -298,7 +298,13 @@ data: [
 ### `ogServerUrl`
 - **Type:** `string`
 - **Mandatory:** No
-Url used in the open graph HTML metadata of the test report. It's useful to share test report over chat or social network.
+
+Url used in the open graph HTML metadata of the test report.
+
+[OpenGraph protocol](http://ogp.me/) enable smart preview of test report on chat or social network.
+This URL has to be the public URL of the test report's directory. Then you can post your ogServerUrl/index.html on your favorite chat room to share the report with a smart preview.
+
+
 
 ## Metadata
 The report can also show on which browser / device a feature has been executed. It is shown on the featurs overview in the table as well as on the feature overview in a container.

--- a/README.MD
+++ b/README.MD
@@ -295,6 +295,11 @@ data: [
 ]
 ```
 
+### `ogServerUrl`
+- **Type:** `string`
+- **Mandatory:** No
+Url used in the open graph HTML metadata of the test report. It's useful to share test report over chat or social network.
+
 ## Metadata
 The report can also show on which browser / device a feature has been executed. It is shown on the featurs overview in the table as well as on the feature overview in a container.
 

--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -9,12 +9,14 @@ const path = require('path');
 const uuid = require('uuid/v4');
 const moment = require('moment');
 const collectJSONS = require('./collect-jsons');
+const openGraphImage = require('./open-graph-image');
 
 const REPORT_STYLESHEET = 'style.css';
 const GENERIC_JS = 'generic.js';
 const INDEX_HTML = 'index.html';
 const FEATURE_FOLDER = 'features';
 const FEATURES_OVERVIEW_INDEX_TEMPLATE = 'features-overview.index.tmpl';
+const RESULT_PREVIEW_SVG = 'result-preview.svg';
 const CUSTOMDATA_TEMPLATE = 'components/custom-data.tmpl';
 let FEATURES_OVERVIEW_TEMPLATE = 'components/features-overview.tmpl';
 const FEATURES_OVERVIEW_CUSTOM_METADATA_TEMPLATE = 'components/features-overview-custom-metadata.tmpl';
@@ -59,6 +61,7 @@ function generateReport(options) {
   const displayDuration = options.displayDuration || false;
   const durationInMS = options.durationInMS || false;
   const pageTitle = options.pageTitle || 'Multiple Cucumber HTML Reporter';
+  const ogServer = options.ogServerUrl || '';
   const pageFooter = options.pageFooter || false;
 
   fs.ensureDirSync(reportPath);
@@ -431,6 +434,11 @@ function generateReport(options) {
       (firstPaddingChar === stringLength - 2 && string[stringLength - 1] === '=');
   }
 
+  function _generateOpenGraphDescription(suite){
+    return (_.keys(RESULT_STATUS).map( (key) =>
+        `${RESULT_STATUS[key]}: ${suite.featureCount[key]}`))
+        .join(', ')
+  }
   /**
    * Generate the features overview
    * @param {object} suite JSON object with all the features and scenarios
@@ -467,9 +475,17 @@ function generateReport(options) {
         styles: _readTemplateFile(suite.style),
         genericScript: _readTemplateFile(GENERIC_JS),
         pageTitle: pageTitle,
+        ogDescription: _generateOpenGraphDescription(suite),
+        ogServer: ogServer,
         reportName: reportName,
         pageFooter: pageFooter
       })
+    );
+    const imageSummary = openGraphImage.generate(suite);
+    const resultPreviewSvg = path.resolve(reportPath, RESULT_PREVIEW_SVG);
+    fs.writeFileSync(
+        resultPreviewSvg,
+        imageSummary
     );
   }
 

--- a/lib/open-graph-image.js
+++ b/lib/open-graph-image.js
@@ -1,0 +1,56 @@
+'use strict';
+const fs = require('fs-extra');
+const path = require('path');
+const _ = require('lodash');
+const IMAGE_SUMMARY_TEMPLATE = 'components/result-preview.tmpl';
+
+/**
+ * Read a template file and return it's content
+ * @param {string} fileName
+ * @return {*} Content of the file
+ * @private
+ */
+function _readTemplateFile(fileName) {
+    if (fileName) {
+        try {
+            fs.accessSync(fileName, fs.constants.R_OK);
+            return fs.readFileSync(fileName, 'utf-8');
+        } catch (err) {
+            return fs.readFileSync(path.join(__dirname, '..', 'templates', fileName), 'utf-8');
+        }
+    } else {
+        return "";
+    }
+}
+
+/**
+ * Generate result summary image
+ * @param {object} suite JSON object with all the features and scenarios
+ * @return {string} svg image
+ */
+function generateSummaryImage(suite){
+    function roundToTwo(num) {
+        return +(Math.round(Number(num)  + "e+2")  + "e-2");
+    }
+    let accumulator = roundToTwo(suite.featureCount.skippedPercentage || 0);
+    function getNextValue(val) {
+        const fill1 = 0;
+        const skip1 = accumulator;
+        const fill2 = roundToTwo(val || 0);
+        const skip2 = roundToTwo(100 - fill1 - skip1 - fill2);
+        accumulator = roundToTwo(accumulator + fill2);
+        return  `${fill1} ${skip1} ${fill2} ${skip2}`;
+    }
+
+    return _.template(_readTemplateFile(IMAGE_SUMMARY_TEMPLATE))({
+        skippedDasharray: `${accumulator} ${100 - accumulator} 0 0`,
+        passedDasharray: getNextValue(suite.featureCount.passedPercentage),
+        notDefinedDasharray:  getNextValue(suite.featureCount.notdefinedPercentage),
+        pendingDasharray: getNextValue(suite.featureCount.pendingPercentage),
+        ambiguousDasharray: getNextValue(suite.featureCount.ambiguousPercentage),
+    });
+}
+
+module.exports = {
+    generate: generateSummaryImage
+};

--- a/lib/open-graph-image.js
+++ b/lib/open-graph-image.js
@@ -11,16 +11,7 @@ const IMAGE_SUMMARY_TEMPLATE = 'components/result-preview.tmpl';
  * @private
  */
 function _readTemplateFile(fileName) {
-    if (fileName) {
-        try {
-            fs.accessSync(fileName, fs.constants.R_OK);
-            return fs.readFileSync(fileName, 'utf-8');
-        } catch (err) {
-            return fs.readFileSync(path.join(__dirname, '..', 'templates', fileName), 'utf-8');
-        }
-    } else {
-        return "";
-    }
+    return fs.readFileSync(path.join(__dirname, '..', 'templates', fileName), 'utf-8');
 }
 
 /**

--- a/templates/components/result-preview.tmpl
+++ b/templates/components/result-preview.tmpl
@@ -1,0 +1,46 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+    <style>
+        circle {
+            fill: none;
+            stroke-width: 6;
+            stroke: gold;
+
+        }
+        .failed {
+            stroke: #E74C3C;
+        }
+        .skipped {
+            stroke: #3498DB;
+            stroke-dasharray: <%= skippedDasharray %>;
+        }
+        .passed {
+            stroke: #1ABB9C;
+            stroke-dasharray: <%= passedDasharray %>;
+        }
+        .not-defined {
+            stroke: #F39C12;
+            stroke-dasharray: <%= notDefinedDasharray %>;
+        }
+        .pending {
+            stroke: #FFD119;
+            stroke-dasharray: <%= pendingDasharray %>;
+        }
+        .ambiguous {
+            stroke: #E74C3C;
+            stroke-dasharray: <%= ambiguousDasharray %>;
+        }
+
+    </style>
+        <circle r="25%" cx="50%" cy="50%" class="failed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="skipped">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="passed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="not-defined">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="pending">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="ambiguous">
+        </circle>
+</svg>

--- a/templates/features-overview.index.tmpl
+++ b/templates/features-overview.index.tmpl
@@ -10,7 +10,7 @@
 
         <!-- openGraph preview -->
         <meta property="og:title" content="<%= pageTitle %>" />
-        <meta property="og:type" content="article" />
+        <meta property="og:type" content="website" />
         <meta property="og:description" content="<%= ogDescription %>" />
         <meta property="og:image" content="<%= ogServer %>/result-preview.svg"/>
         <meta property="og:url" content="<%= ogServer %>/index.html"/>

--- a/templates/features-overview.index.tmpl
+++ b/templates/features-overview.index.tmpl
@@ -8,6 +8,13 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
     	<title><%= pageTitle %></title>
 
+        <!-- openGraph preview -->
+        <meta property="og:title" content="<%= pageTitle %>" />
+        <meta property="og:type" content="article" />
+        <meta property="og:description" content="<%= ogDescription %>" />
+        <meta property="og:image" content="<%= ogServer %>/result-preview.svg"/>
+        <meta property="og:url" content="<%= ogServer %>/index.html"/>
+
         <!-- Bootstrap -->
         <link rel="stylesheet" href="assets/css/bootstrap.min.css">
         <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->

--- a/test/unit/data/image-summary/result-preview-all.svg
+++ b/test/unit/data/image-summary/result-preview-all.svg
@@ -1,0 +1,46 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+    <style>
+        circle {
+            fill: none;
+            stroke-width: 6;
+            stroke: gold;
+
+        }
+        .failed {
+            stroke: #E74C3C;
+        }
+        .skipped {
+            stroke: #3498DB;
+            stroke-dasharray: 15 85 0 0;
+        }
+        .passed {
+            stroke: #1ABB9C;
+            stroke-dasharray: 0 15 40 45;
+        }
+        .not-defined {
+            stroke: #F39C12;
+            stroke-dasharray: 0 55 9.5 35.5;
+        }
+        .pending {
+            stroke: #FFD119;
+            stroke-dasharray: 0 64.5 10.5 25;
+        }
+        .ambiguous {
+            stroke: #E74C3C;
+            stroke-dasharray: 0 75 10 15;
+        }
+
+    </style>
+        <circle r="25%" cx="50%" cy="50%" class="failed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="skipped">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="passed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="not-defined">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="pending">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="ambiguous">
+        </circle>
+</svg>

--- a/test/unit/data/image-summary/result-preview-failed.svg
+++ b/test/unit/data/image-summary/result-preview-failed.svg
@@ -1,0 +1,46 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+    <style>
+        circle {
+            fill: none;
+            stroke-width: 6;
+            stroke: gold;
+
+        }
+        .failed {
+            stroke: #E74C3C;
+        }
+        .skipped {
+            stroke: #3498DB;
+            stroke-dasharray: 0 100 0 0;
+        }
+        .passed {
+            stroke: #1ABB9C;
+            stroke-dasharray: 0 0 0 100;
+        }
+        .not-defined {
+            stroke: #F39C12;
+            stroke-dasharray: 0 0 0 100;
+        }
+        .pending {
+            stroke: #FFD119;
+            stroke-dasharray: 0 0 0 100;
+        }
+        .ambiguous {
+            stroke: #E74C3C;
+            stroke-dasharray: 0 0 0 100;
+        }
+
+    </style>
+        <circle r="25%" cx="50%" cy="50%" class="failed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="skipped">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="passed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="not-defined">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="pending">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="ambiguous">
+        </circle>
+</svg>

--- a/test/unit/data/image-summary/result-preview-passed-failed.svg
+++ b/test/unit/data/image-summary/result-preview-passed-failed.svg
@@ -1,0 +1,46 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+    <style>
+        circle {
+            fill: none;
+            stroke-width: 6;
+            stroke: gold;
+
+        }
+        .failed {
+            stroke: #E74C3C;
+        }
+        .skipped {
+            stroke: #3498DB;
+            stroke-dasharray: 0 100 0 0;
+        }
+        .passed {
+            stroke: #1ABB9C;
+            stroke-dasharray: 0 0 90.91 9.09;
+        }
+        .not-defined {
+            stroke: #F39C12;
+            stroke-dasharray: 0 90.91 0 9.09;
+        }
+        .pending {
+            stroke: #FFD119;
+            stroke-dasharray: 0 90.91 0 9.09;
+        }
+        .ambiguous {
+            stroke: #E74C3C;
+            stroke-dasharray: 0 90.91 0 9.09;
+        }
+
+    </style>
+        <circle r="25%" cx="50%" cy="50%" class="failed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="skipped">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="passed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="not-defined">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="pending">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="ambiguous">
+        </circle>
+</svg>

--- a/test/unit/data/image-summary/result-preview-passed.svg
+++ b/test/unit/data/image-summary/result-preview-passed.svg
@@ -1,0 +1,46 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+    <style>
+        circle {
+            fill: none;
+            stroke-width: 6;
+            stroke: gold;
+
+        }
+        .failed {
+            stroke: #E74C3C;
+        }
+        .skipped {
+            stroke: #3498DB;
+            stroke-dasharray: 0 100 0 0;
+        }
+        .passed {
+            stroke: #1ABB9C;
+            stroke-dasharray: 0 0 100 0;
+        }
+        .not-defined {
+            stroke: #F39C12;
+            stroke-dasharray: 0 100 0 0;
+        }
+        .pending {
+            stroke: #FFD119;
+            stroke-dasharray: 0 100 0 0;
+        }
+        .ambiguous {
+            stroke: #E74C3C;
+            stroke-dasharray: 0 100 0 0;
+        }
+
+    </style>
+        <circle r="25%" cx="50%" cy="50%" class="failed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="skipped">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="passed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="not-defined">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="pending">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="ambiguous">
+        </circle>
+</svg>

--- a/test/unit/data/image-summary/result-preview.svg
+++ b/test/unit/data/image-summary/result-preview.svg
@@ -1,0 +1,46 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+    <style>
+        circle {
+            fill: none;
+            stroke-width: 6;
+            stroke: gold;
+
+        }
+        .failed {
+            stroke: #E74C3C;
+        }
+        .skipped {
+            stroke: #3498DB;
+            stroke-dasharray: 20 80 0 0;
+        }
+        .passed {
+            stroke: #1ABB9C;
+            stroke-dasharray: 0 20 60 20;
+        }
+        .not-defined {
+            stroke: #F39C12;
+            stroke-dasharray: 0 80 0 20;
+        }
+        .pending {
+            stroke: #FFD119;
+            stroke-dasharray: 0 80 0 20;
+        }
+        .ambiguous {
+            stroke: #E74C3C;
+            stroke-dasharray: 0 80 0 20;
+        }
+
+    </style>
+        <circle r="25%" cx="50%" cy="50%" class="failed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="skipped">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="passed">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="not-defined">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="pending">
+        </circle>
+        <circle r="25%" cx="50%" cy="50%" class="ambiguous">
+        </circle>
+</svg>

--- a/test/unit/open-graph-summary.spec.js
+++ b/test/unit/open-graph-summary.spec.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+const openGraph = require('../../lib/open-graph-image');
+const REPORT_PATH = './.tmp/';
+
+describe('open-graph-image.js', () => {
+    it('should generate svg for mixed result', () => {
+
+        const suite = {
+            featureCount: {
+                failededPercentage: 20,
+                skippedPercentage: 20,
+                passedPercentage: 60,
+                pendingPercentage:0,
+                notdefinedPercentage: 0,
+                ambiguousPercentage: 0,
+            }
+        };
+        const expectedResult = fs.readFileSync(path.resolve('test/unit/data/image-summary/result-preview.svg'), 'utf-8');
+        const result = openGraph.generate(suite);
+        expect(result).toEqual(expectedResult);
+    });
+    it('should generate svg for all passed result', () => {
+
+        const suite = {
+            featureCount: {
+                failededPercentage: 0,
+                skippedPercentage: 0,
+                passedPercentage: 100,
+                pendingPercentage:0,
+                notdefinedPercentage: 0,
+                ambiguousPercentage: 0,
+            }
+        };
+        const expectedResult = fs.readFileSync(path.resolve('test/unit/data/image-summary/result-preview-passed.svg'), 'utf-8');
+        const result = openGraph.generate(suite);
+        expect(result).toEqual(expectedResult);
+    });
+    it('should generate svg for all failed result', () => {
+
+        const suite = {
+            featureCount: {
+                failededPercentage: 100,
+                skippedPercentage: 0,
+                passedPercentage: 0,
+                pendingPercentage:0,
+                notdefinedPercentage: 0,
+                ambiguousPercentage: 0,
+            }
+        };
+        const expectedResult = fs.readFileSync(path.resolve('test/unit/data/image-summary/result-preview-failed.svg'), 'utf-8');
+        const result = openGraph.generate(suite);
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('should generate svg for all results', () => {
+
+        const suite = {
+            featureCount: {
+                failededPercentage: 15,
+                skippedPercentage: 15,
+                passedPercentage: 40,
+                pendingPercentage:10.5,
+                notdefinedPercentage: 9.5,
+                ambiguousPercentage: 10,
+            }
+        };
+        const expectedResult = fs.readFileSync(path.resolve('test/unit/data/image-summary/result-preview-all.svg'), 'utf-8');
+        const result = openGraph.generate(suite);
+        expect(result).toEqual(expectedResult);
+    });
+    it('should generate svg for passed failed results', () => {
+
+        const suite = {
+            featureCount: {
+                failededPercentage: 9.01,
+                skippedPercentage: 0,
+                passedPercentage: 90.91,
+                pendingPercentage: 0,
+                notdefinedPercentage: 0,
+            }
+        };
+        const expectedResult = fs.readFileSync(path.resolve('test/unit/data/image-summary/result-preview-passed-failed.svg'), 'utf-8');
+        const result = openGraph.generate(suite);
+        expect(result).toEqual(expectedResult);
+    });
+});


### PR DESCRIPTION
Hello,
This PR to add openGraph HTML metadata. So that the test report can be preview when shared on chat or social network.
<img width="517" alt="capture d ecran 2019-03-07 a 19 52 10" src="https://user-images.githubusercontent.com/11928848/53981608-2c01a480-4113-11e9-8c47-ccd8b1da559f.png">
