### PR TITLE
Added html escaping for opening and closing brackets in embedded text

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -334,7 +334,7 @@ function generateReport(options) {
 						]);
 					} else if (embedding.mime_type === 'text/plain' || (embedding.media && embedding.media.type === 'text/plain')) {
 						step.text = (step.text ? step.text : []).concat([
-							_isBase64(embedding.data) ? Base64.decode(embedding.data) :
+							_isBase64(embedding.data) ? _escapeHtml(Base64.decode(embedding.data)) :
 								embedding.data
 						]);
 					} else if (embedding.mime_type === 'image/png' || (embedding.media && embedding.media.type === 'image/png')) {
@@ -433,6 +433,16 @@ function generateReport(options) {
 		return firstPaddingChar === -1 ||
 			firstPaddingChar === stringLength - 1 ||
 			(firstPaddingChar === stringLength - 2 && string[ stringLength - 1 ] === '=');
+	}
+
+	/**
+	 * Escape html in string
+	 * @param string
+	 * @return {string}
+	 * @private
+	 */
+	function _escapeHtml(string) {
+		return string.replace(/</g, '&lt;').replace(/>/g, '&gt;')
 	}
 
 	/**

--- a/templates/components/scenarios.tmpl
+++ b/templates/components/scenarios.tmpl
@@ -159,7 +159,7 @@
                                             <% } %>
 
                                                   <% if (step.image) { %>
-                                                    <a href="#info<%= scenarioIndex %><%= stepIndex %>-image" data-toggle="collapse">Screenshot +</a>
+                                                    <a href="#info<%= scenarioIndex %><%= stepIndex %>-image" data-toggle="collapse">+ Screenshot</a>
                                                     <% } %>
 
                                                       <% if (!_.isEmpty(step.attachments)) { %>


### PR DESCRIPTION
**Fix for the following issue:**
Embeddings of type text/plain can break the report if they include HTML tags

**Example**
Base64 content from *.cucumber.json:
 ```VGltZWQgb3V0IHJldHJ5aW5nOiBleHBlY3RlZCAnPHRhYmxlPicgbm90IHRvIGNvbnRhaW4gdGV4dCAnRGllc2UgQmVtZXJrdW5nIGRhcmYgbmllIGVyc2NoZWluZW4hJw==```
Decoded content in html report:
```Timed out retrying: expected '<table>' not to contain text 'Diese Bemerkung darf nie erscheinen!'```

**Result**
Report is cut off after step containing the decoded content, because everything else is rendered within a table.