### PR TITLE
Show duration in features overview when customMetadata is true

### DIFF
--- a/templates/components/features-overview-custom-metadata.tmpl
+++ b/templates/components/features-overview-custom-metadata.tmpl
@@ -24,6 +24,9 @@
                         <% _.each(suite.features[0].metadata, function(metadatum, metadatumIndex) { %>
                         <th><%= metadatum.name %></th>
                         <%});%>
+                        <% if (suite.displayDuration) { %>
+                        <th>Duration</th>
+                        <% } %>
                         <th>Total</th>
                         <th>Passed</th>
                         <th>Failed</th>
@@ -91,6 +94,9 @@
                             <%=metadatum.value%>
                         </td>
                         <% }); %>
+                        <% if (suite.displayDuration) { %>
+                        <td><%= feature.time %></td>
+                        <% } %>
                         <td><%= feature.scenarios.total %></td>
                         <td><%= feature.scenarios.passed %></td>
                         <td><%= feature.scenarios.failed %></td>


### PR DESCRIPTION
PR makes it so the Duration column is shown in the features overview even if customMetadata is set to true when displayDuration is also set to true. I think it's nicer to enable this entry via displayDuration, rather than add the duration back as a new custom metadata field. 

I've put the column in the same place as it would be when not using custom metadata (I.e, after the custom metadata / App+Browser+etc info).