### PR TITLE
#106 Escape < and > with &lt/&gt

### DIFF
--- a/templates/components/scenarios.tmpl
+++ b/templates/components/scenarios.tmpl
@@ -113,7 +113,9 @@
 
                 <div class="text">
                     <span class="keyword highlight"><%= step.keyword %></span>
-                    <%= step.name %>
+                    <% if(step.name) { %>
+                        <%= step.name.replace(/</g, '&lt;').replace(/>/g, '&gt;') %>
+                    <% } %>
                     <% if(suite.displayDuration) { %>
                         <% if (step.time) { %>
                             <span class="duration"><%= step.time %></span>


### PR DESCRIPTION
PR escapes the < > symbols with &lt and &gt to prevent them being interpreted as HTML. Could probably better escape this to catch other symbols, but for now this solves the original issue I had.

Fixes #106 