### PR TITLE
Added capability to show REST response in report 

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -355,6 +355,11 @@ function generateReport(options) {
 				});
 			}
 
+            if (step.doc_string !== undefined) {
+                step.id = `${uuid()}.${scenario.id}.${step.name}`.replace(/[^a-zA-Z0-9-_]/g, '-');
+                step.restWireData = step.doc_string.value.split(/[>]/).join('').replace(new RegExp('\r?\n', 'g'), '<br />').split('response');
+            }
+
 			if (!step.result
 				// Don't log steps that don't have a text/hidden/images/attachments unless they are failed.
 				// This is for the hooks

--- a/templates/components/scenarios.tmpl
+++ b/templates/components/scenarios.tmpl
@@ -115,6 +115,16 @@
                     <span class="keyword highlight"><%= step.keyword %></span>
                     <% if(step.name) { %>
                         <%= step.name.replace(/</g, '&lt;').replace(/>/g, '&gt;') %>
+                        <% if(step.restWireData) { %>
+                            <button type="button" class="btn btn-success btn-sm" data-toggle="collapse" data-target="#<%= step.id%>">REST Query</button>
+                            <div id="<%= step.id%>" class="collapse">
+                                <div class="panel panel-default">
+                                    <div class="panel-body">
+                                        <pre><%= step.restWireData %></pre>
+                                    </div>
+                                </div>
+                            </div>
+                        <% } %>
                     <% } %>
                     <% if(suite.displayDuration) { %>
                         <% if (step.time) { %>

--- a/test/unit/data/json/with_rest_doc_string.json
+++ b/test/unit/data/json/with_rest_doc_string.json
@@ -1,0 +1,141 @@
+[
+  {
+    "line": 1,
+    "elements": [
+      {
+        "line": 13,
+        "name": "",
+        "description": "",
+        "type": "background",
+        "keyword": "Background",
+        "steps": [
+          {
+            "name": "url \"https:\/\/swapi.co\/api\"",
+            "result": {
+              "duration": 1602504,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "*",
+            "line": 15,
+            "doc_string": {
+              "content_type": "",
+              "value": "17:30:35.244 karate.env system property was: demo",
+              "line": 15
+            }
+          }
+        ]
+      },
+      {
+        "line": 18,
+        "name": "Create an API test that returns all the planets in the SW. Validate that ALL returns are as expected.",
+        "description": "",
+        "id": "create_api_validate_all_planet_and_response",
+        "type": "scenario",
+        "keyword": "Scenario",
+        "steps": [
+          {
+            "name": "path 'planets'",
+            "result": {
+              "duration": 4155735,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "Given",
+            "line": 19
+          },
+          {
+            "name": "method get",
+            "result": {
+              "duration": 4060535948,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "When",
+            "line": 20,
+            "doc_string": {
+              "content_type": "",
+              "value": "17:30:35.402 request:\n1 > GET https:\/\/swapi.co\/api\/planets\n1 > Accept-Encoding: gzip,deflate\n1 > Connection: Keep-Alive\n1 > Host: swapi.co\n1 > User-Agent: Apache-HttpClient\/4.5.5 (Java\/1.8.0_242)\n\n17:30:38.408 response time in milliseconds: 3002.61\n1 < 301\n1 < CF-Cache-Status: DYNAMIC\n1 < CF-RAY: 560eda61f8296b6b-LHR\n1 < Connection: keep-alive\n1 < Content-Type: text\/html; charset=utf-8\n1 < Date: Thu, 06 Feb 2020 17:30:38 GMT\n1 < Expect-CT: max-age=604800, report-uri=\"https:\/\/report-uri.cloudflare.com\/cdn-cgi\/beacon\/expect-ct\"\n1 < Location: https:\/\/swapi.co\/api\/planets\/\n1 < Server: cloudflare\n1 < Set-Cookie: __cfduid=da2652607b9b30b4e232d4a0a253db7111581010237; expires=Sat, 07-Mar-20 17:30:37 GMT; path=\/; domain=.swapi.co; HttpOnly; SameSite=Lax; Secure\n1 < Transfer-Encoding: chunked\n1 < Via: 1.1 vegur\n1 < X-Frame-Options: SAMEORIGIN\n\n\n17:30:38.411 request:\n2 > GET https:\/\/swapi.co\/api\/planets\n2 > Accept-Encoding: gzip,deflate\n2 > Connection: Keep-Alive\n2 > Cookie: __cfduid=da2652607b9b30b4e232d4a0a253db7111581010237\n2 > Host: swapi.co\n2 > User-Agent: Apache-HttpClient\/4.5.5 (Java\/1.8.0_242)\n\n17:30:39.317 response time in milliseconds: 903.69\n2 < 200\n2 < Allow: GET, HEAD, OPTIONS\n2 < CF-Cache-Status: DYNAMIC\n2 < CF-RAY: 560eda66beab6b6b-LHR\n2 < Connection: keep-alive\n2 < Content-Type: application\/json\n2 < Date: Thu, 06 Feb 2020 17:30:39 GMT\n2 < Etag: W\/\"394d177de8df8accc41f9427b749ef4a\"\n2 < Expect-CT: max-age=604800, report-uri=\"https:\/\/report-uri.cloudflare.com\/cdn-cgi\/beacon\/expect-ct\"\n2 < Server: cloudflare\n2 < Transfer-Encoding: chunked\n2 < Vary: Accept, Cookie\n2 < Via: 1.1 vegur\n2 < X-Frame-Options: SAMEORIGIN\n{\"count\":61,\"next\":\"https:\/\/swapi.co\/api\/planets\/?page=2\",\"previous\":null,\"results\":[{\"name\":\"Alderaan\",\"rotation_period\":\"24\",\"orbital_period\":\"364\",\"diameter\":\"12500\",\"climate\":\"temperate\",\"gravity\":\"1 standard\",\"terrain\":\"grasslands, mountains\",\"surface_water\":\"40\",\"population\":\"2000000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/5\/\",\"https:\/\/swapi.co\/api\/people\/68\/\",\"https:\/\/swapi.co\/api\/people\/81\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/6\/\",\"https:\/\/swapi.co\/api\/films\/1\/\"],\"created\":\"2014-12-10T11:35:48.479000Z\",\"edited\":\"2014-12-20T20:58:18.420000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/2\/\"},{\"name\":\"Yavin IV\",\"rotation_period\":\"24\",\"orbital_period\":\"4818\",\"diameter\":\"10200\",\"climate\":\"temperate, tropical\",\"gravity\":\"1 standard\",\"terrain\":\"jungle, rainforests\",\"surface_water\":\"8\",\"population\":\"1000\",\"residents\":[],\"films\":[\"https:\/\/swapi.co\/api\/films\/1\/\"],\"created\":\"2014-12-10T11:37:19.144000Z\",\"edited\":\"2014-12-20T20:58:18.421000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/3\/\"},{\"name\":\"Hoth\",\"rotation_period\":\"23\",\"orbital_period\":\"549\",\"diameter\":\"7200\",\"climate\":\"frozen\",\"gravity\":\"1.1 standard\",\"terrain\":\"tundra, ice caves, mountain ranges\",\"surface_water\":\"100\",\"population\":\"unknown\",\"residents\":[],\"films\":[\"https:\/\/swapi.co\/api\/films\/2\/\"],\"created\":\"2014-12-10T11:39:13.934000Z\",\"edited\":\"2014-12-20T20:58:18.423000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/4\/\"},{\"name\":\"Dagobah\",\"rotation_period\":\"23\",\"orbital_period\":\"341\",\"diameter\":\"8900\",\"climate\":\"murky\",\"gravity\":\"N\/A\",\"terrain\":\"swamp, jungles\",\"surface_water\":\"8\",\"population\":\"unknown\",\"residents\":[],\"films\":[\"https:\/\/swapi.co\/api\/films\/2\/\",\"https:\/\/swapi.co\/api\/films\/6\/\",\"https:\/\/swapi.co\/api\/films\/3\/\"],\"created\":\"2014-12-10T11:42:22.590000Z\",\"edited\":\"2014-12-20T20:58:18.425000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/5\/\"},{\"name\":\"Bespin\",\"rotation_period\":\"12\",\"orbital_period\":\"5110\",\"diameter\":\"118000\",\"climate\":\"temperate\",\"gravity\":\"1.5 (surface), 1 standard (Cloud City)\",\"terrain\":\"gas giant\",\"surface_water\":\"0\",\"population\":\"6000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/26\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/2\/\"],\"created\":\"2014-12-10T11:43:55.240000Z\",\"edited\":\"2014-12-20T20:58:18.427000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/6\/\"},{\"name\":\"Endor\",\"rotation_period\":\"18\",\"orbital_period\":\"402\",\"diameter\":\"4900\",\"climate\":\"temperate\",\"gravity\":\"0.85 standard\",\"terrain\":\"forests, mountains, lakes\",\"surface_water\":\"8\",\"population\":\"30000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/30\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/3\/\"],\"created\":\"2014-12-10T11:50:29.349000Z\",\"edited\":\"2014-12-20T20:58:18.429000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/7\/\"},{\"name\":\"Naboo\",\"rotation_period\":\"26\",\"orbital_period\":\"312\",\"diameter\":\"12120\",\"climate\":\"temperate\",\"gravity\":\"1 standard\",\"terrain\":\"grassy hills, swamps, forests, mountains\",\"surface_water\":\"12\",\"population\":\"4500000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/3\/\",\"https:\/\/swapi.co\/api\/people\/21\/\",\"https:\/\/swapi.co\/api\/people\/36\/\",\"https:\/\/swapi.co\/api\/people\/37\/\",\"https:\/\/swapi.co\/api\/people\/38\/\",\"https:\/\/swapi.co\/api\/people\/39\/\",\"https:\/\/swapi.co\/api\/people\/42\/\",\"https:\/\/swapi.co\/api\/people\/60\/\",\"https:\/\/swapi.co\/api\/people\/61\/\",\"https:\/\/swapi.co\/api\/people\/66\/\",\"https:\/\/swapi.co\/api\/people\/35\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/5\/\",\"https:\/\/swapi.co\/api\/films\/4\/\",\"https:\/\/swapi.co\/api\/films\/6\/\",\"https:\/\/swapi.co\/api\/films\/3\/\"],\"created\":\"2014-12-10T11:52:31.066000Z\",\"edited\":\"2014-12-20T20:58:18.430000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/8\/\"},{\"name\":\"Coruscant\",\"rotation_period\":\"24\",\"orbital_period\":\"368\",\"diameter\":\"12240\",\"climate\":\"temperate\",\"gravity\":\"1 standard\",\"terrain\":\"cityscape, mountains\",\"surface_water\":\"unknown\",\"population\":\"1000000000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/34\/\",\"https:\/\/swapi.co\/api\/people\/55\/\",\"https:\/\/swapi.co\/api\/people\/74\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/5\/\",\"https:\/\/swapi.co\/api\/films\/4\/\",\"https:\/\/swapi.co\/api\/films\/6\/\",\"https:\/\/swapi.co\/api\/films\/3\/\"],\"created\":\"2014-12-10T11:54:13.921000Z\",\"edited\":\"2014-12-20T20:58:18.432000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/9\/\"},{\"name\":\"Kamino\",\"rotation_period\":\"27\",\"orbital_period\":\"463\",\"diameter\":\"19720\",\"climate\":\"temperate\",\"gravity\":\"1 standard\",\"terrain\":\"ocean\",\"surface_water\":\"100\",\"population\":\"1000000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/22\/\",\"https:\/\/swapi.co\/api\/people\/72\/\",\"https:\/\/swapi.co\/api\/people\/73\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/5\/\"],\"created\":\"2014-12-10T12:45:06.577000Z\",\"edited\":\"2014-12-20T20:58:18.434000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/10\/\"},{\"name\":\"Geonosis\",\"rotation_period\":\"30\",\"orbital_period\":\"256\",\"diameter\":\"11370\",\"climate\":\"temperate, arid\",\"gravity\":\"0.9 standard\",\"terrain\":\"rock, desert, mountain, barren\",\"surface_water\":\"5\",\"population\":\"100000000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/63\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/5\/\"],\"created\":\"2014-12-10T12:47:22.350000Z\",\"edited\":\"2014-12-20T20:58:18.437000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/11\/\"}]}",
+              "line": 20
+            }
+          },
+          {
+            "name": "status 200",
+            "result": {
+              "duration": 9140,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "Then",
+            "line": 21,
+            "doc_string": {
+              "content_type": "",
+              "value": "",
+              "line": 20
+            }
+          },
+          {
+            "name": "def json = read('planetas.json')",
+            "result": {
+              "duration": 3772894,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "*",
+            "line": 22
+          },
+          {
+            "name": "match json == response",
+            "result": {
+              "duration": 496304,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "And",
+            "line": 23
+          }
+        ],
+        "tags": [
+          {
+            "name": "@dojo",
+            "line": 17
+          }
+        ]
+      }
+    ],
+    "name": "Report with JSON rest response",
+    "description": "Report with JSON rest response",
+    "id": "json-report-starwars",
+    "keyword": "Feature",
+    "uri": "starwars.feature",
+    "metadata": {
+      "browser": {
+        "name": "",
+        "version": ""
+      },
+      "device": "",
+      "platform": {
+        "name": "",
+        "version": ""
+      }
+    }
+  }
+]

--- a/test/unit/data/output/merged-output.json
+++ b/test/unit/data/output/merged-output.json
@@ -3209,5 +3209,144 @@
         ]
       }
     ]
+  },
+  {
+    "line": 1,
+    "elements": [
+      {
+        "line": 13,
+        "name": "",
+        "description": "",
+        "type": "background",
+        "keyword": "Background",
+        "steps": [
+          {
+            "name": "url \"https:\/\/swapi.co\/api\"",
+            "result": {
+              "duration": 1602504,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "*",
+            "line": 15,
+            "doc_string": {
+              "content_type": "",
+              "value": "17:30:35.244 karate.env system property was: demo",
+              "line": 15
+            }
+          }
+        ]
+      },
+      {
+        "line": 18,
+        "name": "Create an API test that returns all the planets in the SW. Validate that ALL returns are as expected.",
+        "description": "",
+        "id": "create_api_validate_all_planet_and_response",
+        "type": "scenario",
+        "keyword": "Scenario",
+        "steps": [
+          {
+            "name": "path 'planets'",
+            "result": {
+              "duration": 4155735,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "Given",
+            "line": 19
+          },
+          {
+            "name": "method get",
+            "result": {
+              "duration": 4060535948,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "When",
+            "line": 20,
+            "doc_string": {
+              "content_type": "",
+              "value": "17:30:35.402 request:\n1 > GET https:\/\/swapi.co\/api\/planets\n1 > Accept-Encoding: gzip,deflate\n1 > Connection: Keep-Alive\n1 > Host: swapi.co\n1 > User-Agent: Apache-HttpClient\/4.5.5 (Java\/1.8.0_242)\n\n17:30:38.408 response time in milliseconds: 3002.61\n1 < 301\n1 < CF-Cache-Status: DYNAMIC\n1 < CF-RAY: 560eda61f8296b6b-LHR\n1 < Connection: keep-alive\n1 < Content-Type: text\/html; charset=utf-8\n1 < Date: Thu, 06 Feb 2020 17:30:38 GMT\n1 < Expect-CT: max-age=604800, report-uri=\"https:\/\/report-uri.cloudflare.com\/cdn-cgi\/beacon\/expect-ct\"\n1 < Location: https:\/\/swapi.co\/api\/planets\/\n1 < Server: cloudflare\n1 < Set-Cookie: __cfduid=da2652607b9b30b4e232d4a0a253db7111581010237; expires=Sat, 07-Mar-20 17:30:37 GMT; path=\/; domain=.swapi.co; HttpOnly; SameSite=Lax; Secure\n1 < Transfer-Encoding: chunked\n1 < Via: 1.1 vegur\n1 < X-Frame-Options: SAMEORIGIN\n\n\n17:30:38.411 request:\n2 > GET https:\/\/swapi.co\/api\/planets\n2 > Accept-Encoding: gzip,deflate\n2 > Connection: Keep-Alive\n2 > Cookie: __cfduid=da2652607b9b30b4e232d4a0a253db7111581010237\n2 > Host: swapi.co\n2 > User-Agent: Apache-HttpClient\/4.5.5 (Java\/1.8.0_242)\n\n17:30:39.317 response time in milliseconds: 903.69\n2 < 200\n2 < Allow: GET, HEAD, OPTIONS\n2 < CF-Cache-Status: DYNAMIC\n2 < CF-RAY: 560eda66beab6b6b-LHR\n2 < Connection: keep-alive\n2 < Content-Type: application\/json\n2 < Date: Thu, 06 Feb 2020 17:30:39 GMT\n2 < Etag: W\/\"394d177de8df8accc41f9427b749ef4a\"\n2 < Expect-CT: max-age=604800, report-uri=\"https:\/\/report-uri.cloudflare.com\/cdn-cgi\/beacon\/expect-ct\"\n2 < Server: cloudflare\n2 < Transfer-Encoding: chunked\n2 < Vary: Accept, Cookie\n2 < Via: 1.1 vegur\n2 < X-Frame-Options: SAMEORIGIN\n{\"count\":61,\"next\":\"https:\/\/swapi.co\/api\/planets\/?page=2\",\"previous\":null,\"results\":[{\"name\":\"Alderaan\",\"rotation_period\":\"24\",\"orbital_period\":\"364\",\"diameter\":\"12500\",\"climate\":\"temperate\",\"gravity\":\"1 standard\",\"terrain\":\"grasslands, mountains\",\"surface_water\":\"40\",\"population\":\"2000000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/5\/\",\"https:\/\/swapi.co\/api\/people\/68\/\",\"https:\/\/swapi.co\/api\/people\/81\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/6\/\",\"https:\/\/swapi.co\/api\/films\/1\/\"],\"created\":\"2014-12-10T11:35:48.479000Z\",\"edited\":\"2014-12-20T20:58:18.420000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/2\/\"},{\"name\":\"Yavin IV\",\"rotation_period\":\"24\",\"orbital_period\":\"4818\",\"diameter\":\"10200\",\"climate\":\"temperate, tropical\",\"gravity\":\"1 standard\",\"terrain\":\"jungle, rainforests\",\"surface_water\":\"8\",\"population\":\"1000\",\"residents\":[],\"films\":[\"https:\/\/swapi.co\/api\/films\/1\/\"],\"created\":\"2014-12-10T11:37:19.144000Z\",\"edited\":\"2014-12-20T20:58:18.421000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/3\/\"},{\"name\":\"Hoth\",\"rotation_period\":\"23\",\"orbital_period\":\"549\",\"diameter\":\"7200\",\"climate\":\"frozen\",\"gravity\":\"1.1 standard\",\"terrain\":\"tundra, ice caves, mountain ranges\",\"surface_water\":\"100\",\"population\":\"unknown\",\"residents\":[],\"films\":[\"https:\/\/swapi.co\/api\/films\/2\/\"],\"created\":\"2014-12-10T11:39:13.934000Z\",\"edited\":\"2014-12-20T20:58:18.423000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/4\/\"},{\"name\":\"Dagobah\",\"rotation_period\":\"23\",\"orbital_period\":\"341\",\"diameter\":\"8900\",\"climate\":\"murky\",\"gravity\":\"N\/A\",\"terrain\":\"swamp, jungles\",\"surface_water\":\"8\",\"population\":\"unknown\",\"residents\":[],\"films\":[\"https:\/\/swapi.co\/api\/films\/2\/\",\"https:\/\/swapi.co\/api\/films\/6\/\",\"https:\/\/swapi.co\/api\/films\/3\/\"],\"created\":\"2014-12-10T11:42:22.590000Z\",\"edited\":\"2014-12-20T20:58:18.425000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/5\/\"},{\"name\":\"Bespin\",\"rotation_period\":\"12\",\"orbital_period\":\"5110\",\"diameter\":\"118000\",\"climate\":\"temperate\",\"gravity\":\"1.5 (surface), 1 standard (Cloud City)\",\"terrain\":\"gas giant\",\"surface_water\":\"0\",\"population\":\"6000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/26\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/2\/\"],\"created\":\"2014-12-10T11:43:55.240000Z\",\"edited\":\"2014-12-20T20:58:18.427000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/6\/\"},{\"name\":\"Endor\",\"rotation_period\":\"18\",\"orbital_period\":\"402\",\"diameter\":\"4900\",\"climate\":\"temperate\",\"gravity\":\"0.85 standard\",\"terrain\":\"forests, mountains, lakes\",\"surface_water\":\"8\",\"population\":\"30000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/30\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/3\/\"],\"created\":\"2014-12-10T11:50:29.349000Z\",\"edited\":\"2014-12-20T20:58:18.429000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/7\/\"},{\"name\":\"Naboo\",\"rotation_period\":\"26\",\"orbital_period\":\"312\",\"diameter\":\"12120\",\"climate\":\"temperate\",\"gravity\":\"1 standard\",\"terrain\":\"grassy hills, swamps, forests, mountains\",\"surface_water\":\"12\",\"population\":\"4500000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/3\/\",\"https:\/\/swapi.co\/api\/people\/21\/\",\"https:\/\/swapi.co\/api\/people\/36\/\",\"https:\/\/swapi.co\/api\/people\/37\/\",\"https:\/\/swapi.co\/api\/people\/38\/\",\"https:\/\/swapi.co\/api\/people\/39\/\",\"https:\/\/swapi.co\/api\/people\/42\/\",\"https:\/\/swapi.co\/api\/people\/60\/\",\"https:\/\/swapi.co\/api\/people\/61\/\",\"https:\/\/swapi.co\/api\/people\/66\/\",\"https:\/\/swapi.co\/api\/people\/35\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/5\/\",\"https:\/\/swapi.co\/api\/films\/4\/\",\"https:\/\/swapi.co\/api\/films\/6\/\",\"https:\/\/swapi.co\/api\/films\/3\/\"],\"created\":\"2014-12-10T11:52:31.066000Z\",\"edited\":\"2014-12-20T20:58:18.430000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/8\/\"},{\"name\":\"Coruscant\",\"rotation_period\":\"24\",\"orbital_period\":\"368\",\"diameter\":\"12240\",\"climate\":\"temperate\",\"gravity\":\"1 standard\",\"terrain\":\"cityscape, mountains\",\"surface_water\":\"unknown\",\"population\":\"1000000000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/34\/\",\"https:\/\/swapi.co\/api\/people\/55\/\",\"https:\/\/swapi.co\/api\/people\/74\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/5\/\",\"https:\/\/swapi.co\/api\/films\/4\/\",\"https:\/\/swapi.co\/api\/films\/6\/\",\"https:\/\/swapi.co\/api\/films\/3\/\"],\"created\":\"2014-12-10T11:54:13.921000Z\",\"edited\":\"2014-12-20T20:58:18.432000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/9\/\"},{\"name\":\"Kamino\",\"rotation_period\":\"27\",\"orbital_period\":\"463\",\"diameter\":\"19720\",\"climate\":\"temperate\",\"gravity\":\"1 standard\",\"terrain\":\"ocean\",\"surface_water\":\"100\",\"population\":\"1000000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/22\/\",\"https:\/\/swapi.co\/api\/people\/72\/\",\"https:\/\/swapi.co\/api\/people\/73\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/5\/\"],\"created\":\"2014-12-10T12:45:06.577000Z\",\"edited\":\"2014-12-20T20:58:18.434000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/10\/\"},{\"name\":\"Geonosis\",\"rotation_period\":\"30\",\"orbital_period\":\"256\",\"diameter\":\"11370\",\"climate\":\"temperate, arid\",\"gravity\":\"0.9 standard\",\"terrain\":\"rock, desert, mountain, barren\",\"surface_water\":\"5\",\"population\":\"100000000000\",\"residents\":[\"https:\/\/swapi.co\/api\/people\/63\/\"],\"films\":[\"https:\/\/swapi.co\/api\/films\/5\/\"],\"created\":\"2014-12-10T12:47:22.350000Z\",\"edited\":\"2014-12-20T20:58:18.437000Z\",\"url\":\"https:\/\/swapi.co\/api\/planets\/11\/\"}]}",
+              "line": 20
+            }
+          },
+          {
+            "name": "status 200",
+            "result": {
+              "duration": 9140,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "Then",
+            "line": 21,
+            "doc_string": {
+              "content_type": "",
+              "value": "",
+              "line": 20
+            }
+          },
+          {
+            "name": "def json = read('planetas.json')",
+            "result": {
+              "duration": 3772894,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "*",
+            "line": 22
+          },
+          {
+            "name": "match json == response",
+            "result": {
+              "duration": 496304,
+              "status": "passed"
+            },
+            "match": {
+              "location": "karate",
+              "arguments": []
+            },
+            "keyword": "And",
+            "line": 23
+          }
+        ],
+        "tags": [
+          {
+            "name": "@dojo",
+            "line": 17
+          }
+        ]
+      }
+    ],
+    "name": "Report with JSON rest response",
+    "description": "Report with JSON rest response",
+    "id": "json-report-starwars",
+    "keyword": "Feature",
+    "uri": "starwars.feature",
+    "metadata": {
+      "browser": {
+        "name": "",
+        "version": ""
+      },
+      "device": "",
+      "platform": {
+        "name": "",
+        "version": ""
+      }
+    }
   }
 ]


### PR DESCRIPTION
As a user who uses karate service based testing framework (https://intuit.github.io/karate/), I wanted to see the http wire request and response when my test execute. 

The PR will add this capability. The karate generated json, will add a `doc_string` node to step which contains the wire log. The log is being parsed and emitted in the report.

The report will add a new button in the report 
![image](https://user-images.githubusercontent.com/2842927/74264101-018f7280-4cf8-11ea-9ef9-daed05f8c93a.png)

And expands upon click will show the wire request and response with headers
![image](https://user-images.githubusercontent.com/2842927/74264179-22f05e80-4cf8-11ea-8b6c-1030847c3da2.png)


