### PR TITLE
Add support to skip uuid as part of feature file path to enable stati…

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -129,6 +129,12 @@ The directory in which the report needs to be saved, relative from where the scr
 
 **N.B.:** If you use a npm script from the command line, like for example `npm run generate-report` the `reportPath` will be relative from the path where the script is executed. Executing it from the root of your project will also save the report in the `reportPath` in the root of you project.
 
+### `staticFilePath`
+- **Type:** `boolean`
+- **Mandatory:** No
+
+If true each feature will get a static filename for the html. Use this feature only if you are not running multiple instances of the same tests.
+
 ### `openReportInBrowser`
 - **Type:** `boolean`
 - **Mandatory:** No

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,3 +8,7 @@ We try to achieve a 100% coverage on the Javascript code. Please make sure that 
 - do a npm install
 
 To create a report use `npm test`. To create a report and also check the coverage use `unit.test.coverage`
+
+## Documentation
+
+Make any applicable changes to the documentation.

--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -61,6 +61,7 @@ function generateReport(options) {
 	const pageTitle = options.pageTitle || 'Multiple Cucumber HTML Reporter';
 	const pageFooter = options.pageFooter || false;
 	const useCDN = options.useCDN || false;
+        const staticFilePath = options.staticFilePath || false;
 
 	fs.ensureDirSync(reportPath);
 	fs.ensureDirSync(path.resolve(reportPath, FEATURE_FOLDER));
@@ -177,7 +178,8 @@ function generateReport(options) {
 			feature.isNotdefined = false;
 			feature.isPending = false;
 			suite.featureCount.total++;
-			feature.id = `${ uuid() }.${ feature.id }`.replace(/[^a-zA-Z0-9-_]/g, '-');
+			var idPrefix = staticFilePath ? '' : `${ uuid() }.` ;
+			feature.id = `${ idPrefix }${ feature.id }`.replace(/[^a-zA-Z0-9-_]/g, '-');
 			feature.app = 0;
 			feature.browser = 0;
 

--- a/test/unit/generate-json.spec.js
+++ b/test/unit/generate-json.spec.js
@@ -18,16 +18,19 @@ describe('generate-report.js', () => {
 
             expect(fs.statSync(`${path.join(process.cwd(), REPORT_PATH, 'index.html')}`).isFile())
                 .toEqual(true, 'Index file exists');
+            expect(function() { fs.statSync(`${path.join(process.cwd(), REPORT_PATH, 'features/happy-flow-v2.html')}`); })
+                .toThrow();
             expect(fs.statSync(`${path.join(process.cwd(), REPORT_PATH, 'merged-output.json')}`).isFile())
                 .toEqual(true, 'merged-output.json file exists');
             expect(fs.statSync(`${path.join(process.cwd(), REPORT_PATH, 'enriched-output.json')}`).isFile())
                 .toEqual(true, 'temp-output.json file exists');
         });
-        it('should create a report from the merged found json files with custom data', () => {
+        it('should create a report from the merged found json files with custom data with static file paths', () => {
             fs.removeSync(REPORT_PATH);
             multiCucumberHTMLReporter.generate({
                 jsonDir: './test/unit/data/json',
                 reportPath: REPORT_PATH,
+                staticFilePath: true,
                 saveCollectedJSON: true,
                 reportName: 'You can adjust this report name',
                 customData: {
@@ -46,6 +49,8 @@ describe('generate-report.js', () => {
 
             expect(fs.statSync(`${path.join(process.cwd(), REPORT_PATH, 'index.html')}`).isFile())
                 .toEqual(true, 'Index file exists');
+            expect(fs.statSync(`${path.join(process.cwd(), REPORT_PATH, 'features/happy-flow-v2.html')}`).isFile())
+                .toEqual(true, 'uuid free feature exists');
             expect(fs.statSync(`${path.join(process.cwd(), REPORT_PATH, 'merged-output.json')}`).isFile())
                 .toEqual(true, 'merged-output.json file exists');
             expect(fs.statSync(`${path.join(process.cwd(), REPORT_PATH, 'enriched-output.json')}`).isFile())


### PR DESCRIPTION
Skipping UUIDs as part of the file name is useful when reporting is made on one run at a time.
Therefore adding it as an option makes sense.