### PR TITLE
Update _escapeHtml to only replace html characters if passed in string is actually a string

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -450,7 +450,9 @@ function generateReport(options) {
 	 * @private
 	 */
 	function _escapeHtml(string) {
-		return string.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+		return typeof string === 'string' || string instanceof String
+			? string.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+			: string
 	}
 
 	/**

--- a/test/unit/data/custom-metadata-json/multiple_different_attachements.json
+++ b/test/unit/data/custom-metadata-json/multiple_different_attachements.json
@@ -64,17 +64,29 @@
                   "type": "application/json"
                 }
               },
-	      {
-		"data": "Some plain text message",
+              {
+                "data": "Some plain text message",
                 "media": {
                   "type": "text/plain"
                 }
-	      },
-	      {
-		"data": "{\"yet another json\":5}",
-		"media": {
-	          "type": "application/json"
-		}
+              },
+              {
+                "data": "{\"yet another json\":5}",
+                "media": {
+                  "type": "application/json"
+                }
+              },
+              {
+                "data": 0,
+                "media": {
+                  "type": "application/json"
+                }
+              },
+              {
+                "data": 1,
+                "media": {
+                  "type": "text/plain"
+                }
               }
             ]
           },


### PR DESCRIPTION
Hello, I recently ran into an issue in my automation framework where the error below was being thrown.

```log
TypeError: string.replace is not a function
    at _escapeHtml (/var/lib/jenkins/workspace/msg-wdio-automated-tests/node_modules/multiple-cucumber-html-reporter/lib/generate-report.js:453:17)
    at step.embeddings.forEach (/var/lib/jenkins/workspace/msg-wdio-automated-tests/node_modules/multiple-cucumber-html-reporter/lib/generate-report.js:341:81)
    at Array.forEach (<anonymous>)
    at scenario.steps.forEach.step (/var/lib/jenkins/workspace/msg-wdio-automated-tests/node_modules/multiple-cucumber-html-reporter/lib/generate-report.js:330:21)
    at Array.forEach (<anonymous>)
    at _parseSteps (/var/lib/jenkins/workspace/msg-wdio-automated-tests/node_modules/multiple-cucumber-html-reporter/lib/generate-report.js:325:18)
    at feature.elements.forEach.scenario (/var/lib/jenkins/workspace/msg-wdio-automated-tests/node_modules/multiple-cucumber-html-reporter/lib/generate-report.js:254:15)
    at Array.forEach (<anonymous>)
    at _parseScenarios (/var/lib/jenkins/workspace/msg-wdio-automated-tests/node_modules/multiple-cucumber-html-reporter/lib/generate-report.js:244:20)
    at suite.features.forEach.feature (/var/lib/jenkins/workspace/msg-wdio-automated-tests/node_modules/multiple-cucumber-html-reporter/lib/generate-report.js:190:14)
```

In our code we get thousands of dynamic values from various APIs and log them to the report in various tests. If one of these values is not a string, this error will be thrown. This change will ensure `replace` is only called on instances of strings passed to `_escapeHtml` so this error wont be thrown.