### PR TITLE
Make browsername 'msedge' cause correct browser icon instead of '?'

### DIFF
--- a/templates/components/feature-metadata-overview.tmpl
+++ b/templates/components/feature-metadata-overview.tmpl
@@ -71,7 +71,8 @@
                     <% var browserIcon; %>
                     <% if (['firefox', 'safari', 'chrome'].indexOf(metadata.browser.name.toLowerCase()) > -1) { %>
                     <% browserIcon = metadata.browser.name.toLowerCase(); %>
-                    <% } else if (metadata.browser.name.toLowerCase() === 'edge' || metadata.browser.name.toLowerCase() === 'microsoftedge'){ %>
+                    <% } else if (metadata.browser.name.toLowerCase() === 'edge' || metadata.browser.name.toLowerCase() === 'microsoftedge' ||
+                    metadata.browser.name.toLowerCase() === 'msedge'){ %>
                     <% browserIcon= "edge"; %>
                     <% } else if (metadata.browser.name.toLowerCase() === 'internet explorer'){ %>
                     <% browserIcon= "internet-explorer"; %>

--- a/templates/components/features-overview.tmpl
+++ b/templates/components/features-overview.tmpl
@@ -154,7 +154,8 @@
                             <% var browserIcon; %>
                             <% if (['firefox', 'safari', 'chrome'].indexOf(feature.metadata.browser.name.toLowerCase()) > -1) { %>
                             <% browserIcon = feature.metadata.browser.name.toLowerCase(); %>
-                            <% } else if (feature.metadata.browser.name.toLowerCase() === 'edge' || feature.metadata.browser.name.toLowerCase() === 'microsoftedge'){ %>
+                            <% } else if (feature.metadata.browser.name.toLowerCase() === 'edge' || feature.metadata.browser.name.toLowerCase() === 'microsoftedge' ||
+                            feature.metadata.browser.name.toLowerCase() === 'msedge'){ %>
                             <% browserIcon= "edge"; %>
                             <% } else if (feature.metadata.browser.name.toLowerCase() === 'internet explorer'){ %>
                             <% browserIcon= "internet-explorer"; %>


### PR DESCRIPTION
Hi,

For my project I have, the 'browsername' metadata is set as 'msedge' instead of 'edge' or 'microsoftedge'. I'm using WebdriverIO v6, which (at this moment) does not support changing the metadata for the cucumberJS JSON.

 I thought the easiest way to solve this is to make 'msedge' an option for the correct browser icon as well. 