### PR TITLE
feat(reporter): be able to display the date and time at which the JSON-files were generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ reports/
 .DS_Store
 package-lock.json
 yarn.lock
+*.tgz

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "debug test.js",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/test/test.js"
+        },
+        {
+            "type": "node",
+            "name": "debug current spec file",
+            "request": "launch",
+            "args": [
+              "${file}"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "program": "${workspaceFolder}/node_modules/jasmine/bin/jasmine",
+            "sourceMaps": true,
+            "runtimeArgs": [
+              "--nolazy",
+              "--inspect-brk"
+            ]
+          }
+    ]
+}

--- a/README.MD
+++ b/README.MD
@@ -184,6 +184,12 @@ This expects the durations in the report to be in **nanoseconds**, which might r
 If set to `true` the duration of steps will be expected to be in **milliseconds**, which might result in incorrect durations when using a version of Cucumber(JS 1 or 4) that does report in **nanaseconds**.
 This parameter relies on `displayDuration: true`
 
+### `displayReportTime`
+- **Type:** `boolean`
+- **Mandatory:** No
+
+If set to `true` the date and time at which the JSON-files were generated, is displayed on the Features overview.
+
 ### `useCDN`
 - **Type:** `boolean`
 - **Mandatory:** No

--- a/lib/collect-jsons.js
+++ b/lib/collect-jsons.js
@@ -5,6 +5,17 @@ const fs = require('fs-extra');
 const jsonFile = require('jsonfile');
 const path = require('path');
 const chalk = require('chalk');
+const moment = require('moment');
+
+/**
+ * Format input date to YYYY/MM/DD HH:mm:ss
+ *
+ * @param {Date} date
+ * @returns {string} formatted date in ISO format local time
+ */
+function formatToLocalIso(date) {
+    return moment(date).format('YYYY/MM/DD HH:mm:ss')
+}
 
 module.exports = function collectJSONS(options) {
     const jsonOutput = [];
@@ -20,6 +31,8 @@ module.exports = function collectJSONS(options) {
         files.map(file => {
             // Cucumber json can be  empty, it's likely being created by another process (#47)
             const data = fs.readFileSync(file).toString() || "[]";
+            const stats = fs.statSync(file);
+            const reportTime = stats.birthtime;
 
             JSON.parse(data).map(json => {
                 if (options.metadata && !json.metadata) {
@@ -38,6 +51,11 @@ module.exports = function collectJSONS(options) {
                             }
                         }
                     }, json);
+                }
+
+                if (json.metadata && options.displayReportTime && reportTime) {
+                    json.metadata = Object.assign({reportTime: reportTime}, json.metadata)
+                    json.metadata.reportTime = formatToLocalIso(json.metadata.reportTime)
                 }
 
                 // Only check the feature hooks if there are elements (fail safe)

--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -57,6 +57,7 @@ function generateReport(options) {
 	const reportPath = path.resolve(process.cwd(), options.reportPath);
 	const saveCollectedJSON = options.saveCollectedJSON;
 	const displayDuration = options.displayDuration || false;
+	const displayReportTime = options.displayReportTime || false;
 	const durationInMS = options.durationInMS || false;
 	const pageTitle = options.pageTitle || 'Multiple Cucumber HTML Reporter';
 	const pageFooter = options.pageFooter || false;
@@ -75,6 +76,7 @@ function generateReport(options) {
 		style: style,
 		customStyle: customStyle,
 		useCDN: useCDN,
+		displayReportTime: displayReportTime,
 		displayDuration: displayDuration,
 		browser: 0,
 		name: '',

--- a/templates/components/features-overview.tmpl
+++ b/templates/components/features-overview.tmpl
@@ -33,6 +33,9 @@
                         <% if(+suite.browser > 0) { %>
                         <th>Browser</th>
                         <% } %>
+                        <% if (suite.displayReportTime) { %>
+                        <th>Date</th>
+                        <% } %>
                         <% if (suite.displayDuration) { %>
                         <th>Duration</th>
                         <% } %>
@@ -166,6 +169,9 @@
                             <%= feature.metadata.browser.version %>
                             <% } %>
                         </td>
+                        <% } %>
+                        <% if (suite.displayReportTime) { %>
+                        <td><%= feature.metadata.reportTime%></td>
                         <% } %>
                         <% if (suite.displayDuration) { %>
                         <td><%= feature.time %></td>

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,30 @@ test.generate({
 });
 
 /**
+ * Generate a report for browsers with report time
+ */
+test.generate({
+    saveCollectedJSON: true,
+    jsonDir: './test/unit/data/json/',
+    reportPath: './.tmp/browsers-with-report-time/',
+    reportName: 'You can adjust this report name',
+    customMetadata: false,
+    displayDuration: true,
+    displayReportTime: true,
+    durationInMS: true,
+    customData: {
+        title: 'Run info',
+        data: [
+            {label: 'Project', value: 'Custom project'},
+            {label: 'Release', value: '1.2.3'},
+            {label: 'Cycle', value: 'B11221.34321'},
+            {label: 'Execution Start Time', value: 'Nov 19th 2017, 02:31 PM EST'},
+            {label: 'Execution End Time', value: 'Nov 19th 2017, 02:56 PM EST'}
+        ]
+    }
+});
+
+/**
  * Generate a report with custom metadata
  * NOTE: must be last, if you use customMetadata you cannot reuse generator
  */

--- a/test/unit/collect-jsons.spec.js
+++ b/test/unit/collect-jsons.spec.js
@@ -40,6 +40,24 @@ describe('collect-jsons.js', () => {
                 saveCollectedJSON: true
             })).toEqual(jsonFile.readFileSync(path.resolve(process.cwd(), './test/unit/data/output/merged-output.json')));
         });
+
+        it('should collect the creation date of json files', () => {
+            // Given 
+            const options = {
+                jsonDir: './test/unit/data/json',
+                reportPath: reportPath,
+                displayReportTime: true
+            }
+
+            // When
+            const collectedJSONs = collectJSONS(options)
+
+            // Then
+            collectedJSONs.forEach(json => {
+                expect(json.metadata.reportTime).toBeDefined();
+                expect(json.metadata.reportTime.length).toBe('YYYY/MM/DD HH:mm:ss'.length);
+            })
+        });
     });
 
     describe('failures', () => {

--- a/test/unit/generate-json.spec.js
+++ b/test/unit/generate-json.spec.js
@@ -25,6 +25,20 @@ describe('generate-report.js', () => {
             expect(fs.statSync(`${path.join(process.cwd(), REPORT_PATH, 'enriched-output.json')}`).isFile())
                 .toEqual(true, 'temp-output.json file exists');
         });
+        it('should create a report with the report time', () => {
+            fs.removeSync(REPORT_PATH);
+            multiCucumberHTMLReporter.generate({
+                jsonDir: './test/unit/data/json',
+                reportPath: REPORT_PATH,
+                saveCollectedJSON: true,
+                displayDuration: true,
+                displayReportTime: true
+            });
+
+            expect(fs.statSync(`${path.join(process.cwd(), REPORT_PATH, 'index.html')}`).isFile())
+                .toEqual(true, 'Index file exists');
+            expect(fs.readFileSync(`${path.join(process.cwd(), REPORT_PATH, 'index.html')}`)).toContain('>Date</th>');
+        });
         it('should create a report from the merged found json files with custom data with static file paths', () => {
             fs.removeSync(REPORT_PATH);
             multiCucumberHTMLReporter.generate({


### PR DESCRIPTION
The purpose of this PR is to be able to display the date and time at which the JSON-files were generated. 
A new option called `displayReportTime` has been created for this purpose.

When this option is set to `true`, a new column called `Date` will be added in the Features Overview, just beside the `Duration` column.

This column will display the creation date of the corresponding JSON-file. 
The date is formatted like this: `YYYY/MM/DD HH:mm:ss`, so that the user can sort the report by dates ascending or descending.
