### PR TITLE
feature: include cypress video into report.

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -23,6 +23,7 @@ const SCENARIOS_OVERVIEW_CHART_TEMPLATE = 'components/scenarios-overview.chart.t
 const FEATURE_OVERVIEW_INDEX_TEMPLATE = 'feature-overview.index.tmpl';
 let FEATURE_METADATA_OVERVIEW_TEMPLATE = 'components/feature-metadata-overview.tmpl';
 const FEATURE_CUSTOM_METADATA_OVERVIEW_TEMPLATE = 'components/feature-custom-metadata-overview.tmpl';
+const FEATURE_ATTACHMENTS_TEMPLATE = 'components/feature-attachments.tmpl';
 const SCENARIOS_TEMPLATE = 'components/scenarios.tmpl';
 const RESULT_STATUS = {
 	passed: 'passed',
@@ -529,6 +530,10 @@ function generateReport(options) {
 					}),
 					featureMetadataOverview: _.template(_readTemplateFile(FEATURE_METADATA_OVERVIEW_TEMPLATE))({
 						metadata: feature.metadata,
+						_: _
+					}),
+					featureAttachments: _.template(_readTemplateFile(FEATURE_ATTACHMENTS_TEMPLATE))({
+						attachments: feature.attachments,
 						_: _
 					}),
 					scenarioTemplate: _.template(_readTemplateFile(SCENARIOS_TEMPLATE))({

--- a/templates/components/feature-attachments.tmpl
+++ b/templates/components/feature-attachments.tmpl
@@ -1,0 +1,29 @@
+<div>
+    <div class="x_title">
+        <h2>Attachments</h2>
+        <ul class="nav navbar-right panel_toolbox">
+            <li>
+                <a class="collapse-link">
+                    <i class="fa fa-chevron-up"></i>
+                </a>
+            </li>
+        </ul>
+        <div class="clearfix"></div>
+    </div>
+
+    <% _.each(attachments, function(attachment, attachmentIndex) { %>
+        <div class="x_content">
+            <% if (attachment.mime_type.match('video.*')) { %>
+                <video src="<%= attachment.src %>"
+                    <% if (!_.isEmpty(attachment.controls)) { %> controls="controls" <% } %>
+                    <% if (!_.isEmpty(attachment.autoplay)) { %> autoplay="autoplay" <% } %>
+                    <% if (!_.isEmpty(attachment.loop)) { %> loop="loop" <% } %>
+                    <% if (!_.isEmpty(attachment.muted)) { %> muted="muted" <% } %>
+                    <% if (!_.isEmpty(attachment.height)) { %> height="<%= attachment.height %>" <% } %>
+                    <% if (!_.isEmpty(attachment.width)) { %> width="<%= attachment.width %>" <% } %>
+                />
+            <% } %>
+        </div>
+
+    <% }); %>
+</div>

--- a/templates/feature-overview.index.tmpl
+++ b/templates/feature-overview.index.tmpl
@@ -93,6 +93,16 @@
             <% } %>
         </div>
 
+        <% if (feature.attachments) { %>
+            <div class="row">
+                <div class="col-lg-12">
+                    <div class="x_panel">
+                        <%= featureAttachments %>
+                    </div>
+                </div>
+            </div>
+        <% } %>
+
         <div class="row">
             <%= scenarioTemplate %>
         </div>


### PR DESCRIPTION
This PR enables to add a video to the cucumber-report.
For me this was especially useful, as I record the videos and would like to add them additionally to the screenshots.
As the cucumber-videos are specific to a feature and not a scenario I added them above all scenarios

![image](https://user-images.githubusercontent.com/26124868/128035862-8c3b80ab-99e7-42de-af5a-db733e1e562f.png)

The following attributes can be configured within the cucumber.json

```
feature.attachments.push({
          src: "http://www.myhost.com/video.mp4",
          mime_type: 'video/mp4',
          height: '540',
          width: '860',
          controls: 'true',
          autoplay: 'true',
          loop: 'true',
          muted: 'muted'});
      }
```