### PR TITLE
Scenario tags now searchable

### DIFF
--- a/templates/components/features-overview.tmpl
+++ b/templates/components/features-overview.tmpl
@@ -66,6 +66,13 @@
                             <a href="features/<%= feature.id %>.html"><%= feature.name %></a>
                         </td>
                         <td class="text-center">
+                            <% for(const el of feature.elements) { %>
+                            <% if(el.tags.length > 0) { %>
+                            <% for(const tag of el.tags) { %>
+                            <% if(feature.tags.filter(t=>t.name==tag.name)==0)feature.tags.push(tag) %>
+                            <% } %>
+                            <% } %>
+                            <% } %>
                             <% if (feature.tags) { %>
                             <% var amount = feature.tags.length; %>
                             <% var tags = _.reduce(feature.tags, (tags, tag) => tags + tag.name + ' ', ''); %>

--- a/templates/components/features-overview.tmpl
+++ b/templates/components/features-overview.tmpl
@@ -66,13 +66,13 @@
                             <a href="features/<%= feature.id %>.html"><%= feature.name %></a>
                         </td>
                         <td class="text-center">
-                            <% for(const el of feature.elements) { %>
-                            <% if(el.tags.length > 0) { %>
-                            <% for(const tag of el.tags) { %>
-                            <% if(feature.tags.filter(t=>t.name==tag.name)==0)feature.tags.push(tag) %>
+                            <% _.each(feature.elements, function(element, elementIndex) { %>
+                            <% if(element.tags.length > 0) { %>
+                            <% _.each(element.tags, function(tag, tagIndex) { %>
+                            <% if(feature.tags.filter(t=>t.name==tag.name)==0) feature.tags.push(tag) %>
+                            <% }) %>
                             <% } %>
-                            <% } %>
-                            <% } %>
+                            <% }) %>
                             <% if (feature.tags) { %>
                             <% var amount = feature.tags.length; %>
                             <% var tags = _.reduce(feature.tags, (tags, tag) => tags + tag.name + ' ', ''); %>

--- a/templates/components/features-overview.tmpl
+++ b/templates/components/features-overview.tmpl
@@ -67,7 +67,7 @@
                         </td>
                         <td class="text-center">
                             <% _.each(feature.elements, function(element, elementIndex) { %>
-                            <% if(element.tags.length > 0) { %>
+                            <% if(element.tags && element.tags.length > 0) { %>
                             <% _.each(element.tags, function(tag, tagIndex) { %>
                             <% if(feature.tags.filter(t=>t.name==tag.name)==0) feature.tags.push(tag) %>
                             <% }) %>

--- a/templates/components/features-overview.tmpl
+++ b/templates/components/features-overview.tmpl
@@ -69,7 +69,7 @@
                             <% _.each(feature.elements, function(element, elementIndex) { %>
                             <% if(element.tags && element.tags.length > 0) { %>
                             <% _.each(element.tags, function(tag, tagIndex) { %>
-                            <% if(feature.tags.filter(t=>t.name==tag.name)==0) feature.tags.push(tag) %>
+                            <% if(feature.tags && feature.tags.filter(t=>t.name==tag.name).length==0) feature.tags.push(tag) %>
                             <% }) %>
                             <% } %>
                             <% }) %>


### PR DESCRIPTION
I wanted to search for the tags of my scenarios in features form the main screens search bar. With the current implementation this is not possible. 
My fix adds the tags of the scenarios to the features overview table tags column and you can now search for tags of scenarios.