### PR TITLE
#149 fix: file name formatting by white space

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -183,7 +183,7 @@ function generateReport(options) {
 			feature.isPending = false;
 			suite.featureCount.total++;
 			var idPrefix = staticFilePath ? '' : `${ uuid() }.` ;
-			feature.id = `${ idPrefix }${ feature.id }`.replace(/[^a-zA-Z0-9-_]/g, '-');
+			feature.id = `${ idPrefix }${ feature.id }`.split(" ").join("-");
 			feature.app = 0;
 			feature.browser = 0;
 


### PR DESCRIPTION
first of all Thank you for make nice package. 
this PR is for fix .html file name formatting by white place.
my mother tongue is Korean. i want to make html file by Korean

if feature is `로그인 테스트` it is become `------.html` file not `로그인-테스트.html`.
i want to fix this.