### PR TITLE
More aggresive `_escapeHtml`, and escape `restWireData`

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -369,7 +369,7 @@ function generateReport(options) {
 
             if (step.doc_string !== undefined) {
                 step.id = `${uuid()}.${scenario.id}.${step.name}`.replace(/[^a-zA-Z0-9-_]/g, '-');
-                step.restWireData = step.doc_string.value.split(/[>]/).join('').replace(new RegExp('\r?\n', 'g'), '<br />').split('response');
+                step.restWireData = _escapeHtml(step.doc_string.value).replace(new RegExp('\r?\n', 'g'), '<br />');
             }
 
 			if (!step.result
@@ -459,7 +459,7 @@ function generateReport(options) {
 	 */
 	function _escapeHtml(string) {
 		return typeof string === 'string' || string instanceof String
-			? string.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+			? string.replace(/[^0-9A-Za-z ]/g, chr => '&#' + chr.charCodeAt(0) + ';')
 			: string
 	}
 


### PR DESCRIPTION
`restWireData` was not being HTML escaped, which meant that if any HTML
was returned in a response (which is possible for non-RESTful HTTP requests),
that the HTML was embedding and messing up the HTML for the report page.
This change escapes any returned HTML.

In addition, `_escapeHtml` has also been made more strict, escaping
more than just `<` and `>` characters.
If this implementation is considered _too_ strict, we can modify it to
just replace the "major players" such as happens in [mustache.js](https://github.com/janl/mustache.js/blob/master/mustache.js#L60-L75)