### PR TITLE
Add colors fetching function and use it with donuts

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -207,7 +207,27 @@ If you prefer, you can use CDN for assets.
 - **Mandatory:** No
 
 If you need to add some custom style to your report. Add it like this `customStyle: 'your-path-where/custom.css'`
-Please refer to the `test` directory for an example.
+Customization is now possible also for the doughnut chart by using [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
+The user can define colors for the chart by defining variables for the different categories as follows:
+```css
+:root {
+  --ambiguous-color:#AAAAAA;
+  --failed-color:#BBBBBB;
+  --not-defined-color:#CCCCCC;
+  --passed-color:#DDDDDD;
+  --pending-color:#EEEEEE;
+  --skipped-color:#FFFFFF;
+}
+```
+Please note that these colors do _not_ affect the main colors CSS. To have homogeneous styling you can simply link those
+colors to the variables, e.g.:
+
+```css
+.ambiguous-color {
+    color: var(--ambiguous-color) !important;
+}
+```
+Please refer to the `test` directory and the `embedded-array` test report for a complete color customization example.
 
 ### `overrideStyle`
 - **Type:** `path`

--- a/README.MD
+++ b/README.MD
@@ -206,14 +206,15 @@ If you prefer, you can use CDN for assets.
 - **Type:** `path`
 - **Mandatory:** No
 
-If you need add some custom style to your report. Add it like this `customStyle: 'your-path-where/custom.css'`
+If you need to add some custom style to your report. Add it like this `customStyle: 'your-path-where/custom.css'`
+Please refer to the `test` directory for an example.
 
 ### `overrideStyle`
 - **Type:** `path`
 - **Mandatory:** No
 
-If you need replace default style for your report. Add it like this `overrideStyle: 'your-path-where/custom.css'`
-
+If you need to replace completely the default style for your report. Add it like this `overrideStyle: 'your-path-where/custom.css'`
+Please refer to the `test` directory for an example.
 
 ### `metadata`
 - **Type:** `JSON`

--- a/templates/assets/js/Chart.style.js
+++ b/templates/assets/js/Chart.style.js
@@ -1,0 +1,16 @@
+function getChartColors() {
+    const colorsMap = [
+        {colorVar: "--passed-color", defaultColor: "#26B99A"},
+        {colorVar: "--failed-color", defaultColor: "#E74C3C"},
+        {colorVar: "--pending-color", defaultColor: "#FFD119"},
+        {colorVar: "--skipped-color", defaultColor: "#3498DB"},
+        {colorVar: "--ambiguous-color", defaultColor: "#b73122"},
+        {colorVar: "--not-defined-color", defaultColor: "#F39C12"},
+    ];
+    const colors = []
+    const style = window.getComputedStyle(document.body);
+    for (let i = 0; i < colorsMap.length; i++) {
+         colors.push(style.getPropertyValue(colorsMap[i].colorVar) || colorsMap[i].defaultColor)
+    }
+    return colors
+}

--- a/templates/feature-overview.index.tmpl
+++ b/templates/feature-overview.index.tmpl
@@ -156,6 +156,7 @@
     <% } %>
 
     <!-- Custom -->
+    <script src="../assets/js/Chart.style.js"></script>
     <script>
         var hideResult;
         var showAll;
@@ -187,14 +188,7 @@
                             <%= feature.scenarios.ambiguous %>,
                             <%= feature.scenarios.notDefined %>
                         ],
-                        backgroundColor: [
-                            "#26B99A",
-                            "#E74C3C",
-                            "#FFD119",
-                            "#3498DB",
-                            "#b73122",
-                            "#F39C12"
-                        ]
+                        backgroundColor: getChartColors()
                     }]
                 },
                 options: scenarioOptions

--- a/templates/features-overview.index.tmpl
+++ b/templates/features-overview.index.tmpl
@@ -6,8 +6,7 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-    	<title><%= pageTitle %></title>
-
+        <title><%= pageTitle %></title>
         <% if (useCDN) { %>
             <!-- Bootstrap -->
             <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" />
@@ -122,6 +121,7 @@
         <% } %>
 
         <!-- Custom -->
+        <script src="assets/js/Chart.style.js"></script>
         <script>
             $(document).ready(function () {
                 $('#features-table').dataTable({
@@ -156,14 +156,7 @@
                                 <%= suite.featureCount.pending %>,
                                 <%= suite.featureCount.skipped %>
                             ],
-                            backgroundColor: [
-                                "#26B99A",
-                                "#E74C3C",
-                                "#b73122",
-                                "#F39C12",
-                                "#FFD119",
-                                "#3498DB"
-                            ]
+                            backgroundColor: getChartColors()
                         }]
                     },
                     options: featureOptions
@@ -195,14 +188,7 @@
                                 <%= suite.scenarios.pending %>,
                                 <%= suite.scenarios.skipped %>
                             ],
-                            backgroundColor: [
-                                "#26B99A",
-                                "#E74C3C",
-                                "#b73122",
-                                "#F39C12",
-                                "#FFD119",
-                                "#3498DB"
-                            ]
+                            backgroundColor: getChartColors()
                         }]
                     },
                     options: scenarioOptions

--- a/test/custom.css
+++ b/test/custom.css
@@ -36,3 +36,28 @@ body {
 .skipped-color {
     color: var(--skipped-color) !important;
 }
+
+/* backgrounds */
+.ambiguous-background {
+    background: var(--ambiguous-color) !important;
+}
+
+.failed-background {
+    background: var(--failed-color) !important;
+}
+
+.not-defined-background {
+    background: var(--not-defined-color) !important;
+}
+
+.passed-background {
+    background: var(--passed-color) !important;
+}
+
+.pending-background {
+    background: var(--pending-color) !important;
+}
+
+.skipped-background {
+    background: var(--skipped-color) !important;
+}

--- a/test/custom.css
+++ b/test/custom.css
@@ -1,3 +1,38 @@
 body {
   background: rgb(58,58,58);
 }
+
+/* CSS custom properties are used to style doughnut charts */
+:root {
+  --ambiguous-color:#AAAAAA;
+  --failed-color:#FF0000;
+  --not-defined-color:#0000FF;
+  --passed-color:#00FF00;
+  --pending-color:#FFAA33;
+  --skipped-color:#770077;
+}
+
+/* Style colors are derived from custom properties to have a homogeneous style */
+.ambiguous-color {
+    color: var(--ambiguous-color) !important;
+}
+
+.failed-color {
+    color: var(--failed-color) !important;
+}
+
+.not-defined-color {
+    color: var(--not-defined-color) !important;
+}
+
+.passed-color {
+    color: var(--passed-color) !important;
+}
+
+.pending-color {
+    color: var(--pending-color) !important;
+}
+
+.skipped-color {
+    color: var(--skipped-color) !important;
+}


### PR DESCRIPTION
Fixes #176 

Introduces a `getChartColors` function to fetch the donut chart colors from CSS variables. Updates both the example and the documentation to mention the option.

I wasn't sure if we were happy with introducing CSS variables in the main css file. If we are ok with that, we can apply the changes I made to `custom.css` directly to `style.css`. In that way we can just easily customize everything in `custom.css` by just defining the CSS variables. Seems saner to me but, as I'm not a big expert on CSS, I leave that final decision to you @wswebcreation. :slightly_smiling_face: 