### PR TITLE
Fix pageFooter option and use double-bang on customMetadata

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -47,7 +47,7 @@ function generateReport(options) {
 		throw new Error('An output path for the reports should be defined, no path was provided.');
 	}
 
-	const customMetadata = options.customMetadata || false;
+	const customMetadata = !!options.customMetadata;
 	const customData = options.customData || null;
 	const plainDescription = !!options.plainDescription;
 	const style = options.overrideStyle || REPORT_STYLESHEET;
@@ -62,7 +62,7 @@ function generateReport(options) {
 	const durationInMS = !!options.durationInMS;
 	const hideMetadata = !!options.hideMetadata;
 	const pageTitle = options.pageTitle || 'Multiple Cucumber HTML Reporter';
-	const pageFooter = !!options.pageFooter;
+	const pageFooter = options.pageFooter || null;
 	const useCDN = !!options.useCDN;
 	const staticFilePath = !!options.staticFilePath;
 

--- a/test/custom.css
+++ b/test/custom.css
@@ -12,6 +12,11 @@ body {
   --skipped-color:#770077;
 }
 
+/* Hide darkmode toggle button */
+.fa-toggle-off {
+    display: none
+}
+
 /* Style colors are derived from custom properties to have a homogeneous style */
 .ambiguous-color {
     color: var(--ambiguous-color) !important;

--- a/test/custom.css
+++ b/test/custom.css
@@ -12,7 +12,7 @@ body {
   --skipped-color:#770077;
 }
 
-/* Hide darkmode toggle button */
+/* If your custom theme doesn't properly support dark mode, you can easily hide the toggle button */
 .fa-toggle-off {
     display: none
 }


### PR DESCRIPTION
Fixes #184 

Moves the `pageFooter` option back while aligning `customMetadata` to the other `boolean` options. I've also hidden the darkmode toggle in the custom `CSS` example since it doesn't make sense there.