### PR TITLE
Ensure space is inserted between tags

### DIFF
--- a/templates/feature-overview.index.tmpl
+++ b/templates/feature-overview.index.tmpl
@@ -72,11 +72,13 @@
         <div class="page-title">
             <div class="tags">
                 <% if (feature.tags) { %>
-                <% var amount = feature.tags.length; %>
-                <% if (amount > 0 ){ %>
-                <i class="fa fa-tag<% if(amount > 1 ) {%>s<% } %> fa-lg"></i>
-                <% _.each(feature.tags, (tag) => {%><span class="tag"><%= tag.name %></span><%});%>
-                <% } %>
+                    <% var amount = feature.tags.length; %>
+                    <% if (amount > 0 ){ %>
+                        <i class="fa fa-tag<% if(amount > 1 ) {%>s<% } %> fa-lg"></i>
+                        <% _.each(feature.tags, (tag) => {%>
+                            <span class="tag"><%= tag.name %></span>
+                        <%});%>
+                    <% } %>
                 <% } %>
             </div>
             <h1>Feature:


### PR DESCRIPTION
Fixes #187 

This will insert several spaces in the generated `html` but since we do the same on the scenarios I guess it's fine. At least the space is now consistently inserted everywhere. :slightly_smiling_face: 