### PR TITLE
Fix: colors for pie chart are not consistent with icon colors

### DIFF
--- a/templates/assets/js/Chart.style.js
+++ b/templates/assets/js/Chart.style.js
@@ -2,15 +2,15 @@ function getChartColors() {
     const colorsMap = [
         {colorVar: "--passed-color", defaultColor: "#26B99A"},
         {colorVar: "--failed-color", defaultColor: "#E74C3C"},
-        {colorVar: "--pending-color", defaultColor: "#FFD119"},
-        {colorVar: "--skipped-color", defaultColor: "#3498DB"},
         {colorVar: "--ambiguous-color", defaultColor: "#b73122"},
         {colorVar: "--not-defined-color", defaultColor: "#F39C12"},
+        {colorVar: "--pending-color", defaultColor: "#FFD119"},
+        {colorVar: "--skipped-color", defaultColor: "#3498DB"},
     ];
     const colors = []
     const style = window.getComputedStyle(document.body);
     for (let i = 0; i < colorsMap.length; i++) {
-         colors.push(style.getPropertyValue(colorsMap[i].colorVar) || colorsMap[i].defaultColor)
+        colors.push(style.getPropertyValue(colorsMap[i].colorVar) || colorsMap[i].defaultColor)
     }
     return colors
 }

--- a/templates/assets/js/Chart.style.js
+++ b/templates/assets/js/Chart.style.js
@@ -2,10 +2,10 @@ function getChartColors() {
     const colorsMap = [
         {colorVar: "--passed-color", defaultColor: "#26B99A"},
         {colorVar: "--failed-color", defaultColor: "#E74C3C"},
-        {colorVar: "--ambiguous-color", defaultColor: "#b73122"},
-        {colorVar: "--not-defined-color", defaultColor: "#F39C12"},
         {colorVar: "--pending-color", defaultColor: "#FFD119"},
         {colorVar: "--skipped-color", defaultColor: "#3498DB"},
+        {colorVar: "--ambiguous-color", defaultColor: "#b73122"},
+        {colorVar: "--not-defined-color", defaultColor: "#F39C12"},
     ];
     const colors = []
     const style = window.getComputedStyle(document.body);

--- a/templates/feature-overview.index.tmpl
+++ b/templates/feature-overview.index.tmpl
@@ -197,10 +197,10 @@
                         data: [
                             <%= feature.scenarios.passed %>,
                             <%= feature.scenarios.failed %>,
-                            <%= feature.scenarios.ambiguous %>,
-                            <%= feature.scenarios.notDefined %>,
                             <%= feature.scenarios.pending %>,
-                            <%= feature.scenarios.skipped %>
+                            <%= feature.scenarios.skipped %>,
+                            <%= feature.scenarios.ambiguous %>,
+                            <%= feature.scenarios.notDefined %>
                         ],
                         backgroundColor: getChartColors()
                     }]

--- a/templates/feature-overview.index.tmpl
+++ b/templates/feature-overview.index.tmpl
@@ -197,10 +197,10 @@
                         data: [
                             <%= feature.scenarios.passed %>,
                             <%= feature.scenarios.failed %>,
-                            <%= feature.scenarios.pending %>,
-                            <%= feature.scenarios.skipped %>,
                             <%= feature.scenarios.ambiguous %>,
-                            <%= feature.scenarios.notDefined %>
+                            <%= feature.scenarios.notDefined %>,
+                            <%= feature.scenarios.pending %>,
+                            <%= feature.scenarios.skipped %>
                         ],
                         backgroundColor: getChartColors()
                     }]

--- a/templates/features-overview.index.tmpl
+++ b/templates/features-overview.index.tmpl
@@ -179,10 +179,10 @@
                         labels: [
                             "Passed",
                             "Failed",
-                            "Ambiguous",
-                            "Not Defined",
                             "Pending",
-                            "Skipped"
+                            "Skipped",
+                            "Ambiguous",
+                            "Not Defined"
                         ],
                         datasets: [{
                             data: [

--- a/templates/features-overview.index.tmpl
+++ b/templates/features-overview.index.tmpl
@@ -147,19 +147,19 @@
                         labels: [
                             "Passed",
                             "Failed",
-                            "Ambiguous",
-                            "Not Defined",
                             "Pending",
-                            "Skipped"
+                            "Skipped",
+                            "Ambiguous",
+                            "Not Defined"
                         ],
                         datasets: [{
                             data: [
                                 <%= suite.featureCount.passed %>,
                                 <%= suite.featureCount.failed %>,
-                                <%= suite.featureCount.ambiguous %>,
-                                <%= suite.featureCount.notDefined %>,
                                 <%= suite.featureCount.pending %>,
-                                <%= suite.featureCount.skipped %>
+                                <%= suite.featureCount.skipped %>,
+                                <%= suite.featureCount.ambiguous %>,
+                                <%= suite.featureCount.notDefined %>
                             ],
                             backgroundColor: getChartColors()
                         }]
@@ -188,10 +188,10 @@
                             data: [
                                 <%= suite.scenarios.passed %>,
                                 <%= suite.scenarios.failed %>,
-                                <%= suite.scenarios.ambiguous %>,
-                                <%= suite.scenarios.notDefined %>,
                                 <%= suite.scenarios.pending %>,
-                                <%= suite.scenarios.skipped %>
+                                <%= suite.scenarios.skipped %>,
+                                <%= suite.scenarios.ambiguous %>,
+                                <%= suite.scenarios.notDefined %>
                             ],
                             backgroundColor: getChartColors()
                         }]


### PR DESCRIPTION
## Fix: colors for pie chart are not consistent with icon colors

Hi,

We noticed that the colors of the pie chart and the icons do not match (only the first two entries are correct).
The static lists in `templates/feature-overview.index.tmpl` [L146](https://github.com/wswebcreation/multiple-cucumber-html-reporter/blob/main/templates/features-overview.index.tmpl#L146) and [L178](https://github.com/wswebcreation/multiple-cucumber-html-reporter/blob/main/templates/features-overview.index.tmpl#L178) have been updated to match the lists in [`templates/assets/js/Chart.style.js`](https://github.com/wswebcreation/multiple-cucumber-html-reporter/blob/main/templates/assets/js/Chart.style.js#L2) and `templates/feature-overview.index.tmpl`.

The changes have been checked with the `npm test` command which generates some reports in the `./.tmp/` directory.

## Before (colors not matching)
The current [main branch](https://github.com/wswebcreation/multiple-cucumber-html-reporter/tree/328250123e1ca099ba4f17538853c5d42ccc75d2)

![01-before-broken](https://user-images.githubusercontent.com/59471050/181499609-f4c9f457-b566-4514-8c93-477b1a6ba4ed.png)

## Afterwards (colors are matching)
The applied changes fix the colors of the pie chart according to the icon colors to the right.

![02-fixed](https://user-images.githubusercontent.com/59471050/181534992-201ea63d-b16b-4884-941b-5ca0d0329575.png)

