### PR TITLE
Break scenario description on carriage returns

### DIFF
--- a/templates/feature-overview.index.tmpl
+++ b/templates/feature-overview.index.tmpl
@@ -86,7 +86,7 @@
             </h1>
             <% if (!plainDescription) { %>
                 <p><% if (feature.description && feature.description.length > 0) { %>
-                    <strong>Description: </strong> <%= feature.description %> </p>
+                    <strong>Description: </strong> <%= feature.description.replace(/(?:\r\n|\r|\n)/g, '<br>') %> </p>
                 <% } %>
                <p><strong>File name:</strong>
                     <%= Array.from(feature.uri.replace(/\\/g,'/').split('/')).pop() %>


### PR DESCRIPTION
Fixes #204 

Breaks the `description` field according to EOF modifiers. There is no alignment, i.e. the second line goes under the `Description` tag. Not a big fun of that but I don't think it's worth to have a deeper rework here. At the end of the day we added `plainDescription` to have custom formatting for the description anyway.