### PR TITLE
fix incorrect status icon and pending/skip count in feature details table

### DIFF
--- a/templates/components/features-overview-custom-metadata.tmpl
+++ b/templates/components/features-overview-custom-metadata.tmpl
@@ -75,7 +75,7 @@
                             <% } else if (feature.isNotdefined) { %>
                             <% status = 'Not Defined'; %>
                             <% statusIcon = 'question-circle not-defined-color'; %>
-                            <% } else if (feature.isNotdefined) { %>
+                            <% } else if (feature.isPending) { %>
                             <% status = 'Pending'; %>
                             <% statusIcon = 'minus-circle pending-color'; %>
                             <% } else if (feature.isSkipped) { %>

--- a/templates/components/features-overview-custom-metadata.tmpl
+++ b/templates/components/features-overview-custom-metadata.tmpl
@@ -30,11 +30,11 @@
                         <th>Total</th>
                         <th>Passed</th>
                         <th>Failed</th>
-                        <% if(+suite.scenarios.pending > 0) { %>
-                        <th>Pending</th>
-                        <% } %>
                         <% if(+suite.scenarios.skipped > 0) { %>
                         <th>Skip</th>
+                        <% } %>
+                        <% if(+suite.scenarios.pending > 0) { %>
+                        <th>Pending</th>
                         <% } %>
                         <% if(+suite.scenarios.notDefined > 0) { %>
                         <th>Undefined</th>

--- a/templates/components/features-overview.tmpl
+++ b/templates/components/features-overview.tmpl
@@ -44,11 +44,11 @@
                         <th>Total</th>
                         <th>Passed</th>
                         <th>Failed</th>
-                        <% if(+suite.scenarios.pending > 0) { %>
-                        <th>Pending</th>
-                        <% } %>
                         <% if(+suite.scenarios.skipped > 0) { %>
                         <th>Skip</th>
+                        <% } %>
+                        <% if(+suite.scenarios.pending > 0) { %>
+                        <th>Pending</th>
                         <% } %>
                         <% if(+suite.scenarios.notDefined > 0) { %>
                         <th>Undefined</th>


### PR DESCRIPTION
**Environment (please complete the following information):**
 - multiple-cucumber-html-reporter: commit 5c013eeadaa24e77ff3a166399455aba2d6e1134 (344. commit on the main branch)

**Config of multiple-cucumber-html-reporter**
Error can be reproduced with the `npm test` script in this repository.

**Describe the bug**
The 'Status' icon as well as the 'Pending/Skip' count in the feature details table is displayed incorrectly.

**To Reproduce**
1. Clone this repository
2. `git checkout 5c013eeadaa24e77ff3a166399455aba2d6e1134 # the 344. commit on the main branch`
3. `npm install`
4. `npm test`
5. Open the file `./.tmp/custom-metadata/index.html`

![1-broken](https://user-images.githubusercontent.com/59471050/186467703-220e7710-7cba-44e2-8d5a-f069d4c70ec5.png)

**Expected behavior**
The icons as well as the numbers in the table should be correct.

![2-fixed](https://user-images.githubusercontent.com/59471050/186467877-9c1d213a-5a3f-483e-a2bc-caf215359a07.png)

**Additional context**
Fixing the icon was rather simple.
For fixing the count the two columns `Pending` and `Skip` have been swapped, now it seems to be correct.
But we're not quite sure whether the changes will produce correct results in all expected cases.