### PR TITLE
Remove moment.js and introduce luxon

### DIFF
--- a/lib/collect-jsons.js
+++ b/lib/collect-jsons.js
@@ -4,16 +4,16 @@ const find = require('find');
 const fs = require('fs-extra');
 const jsonFile = require('jsonfile');
 const path = require('path');
-const moment = require('moment');
+const { DateTime } = require('luxon');
 
 /**
- * Format input date to YYYY/MM/DD HH:mm:ss
+ * Formats input date to yyyy/MM/dd HH:mm:ss
  *
  * @param {Date} date
  * @returns {string} formatted date in ISO format local time
  */
 function formatToLocalIso(date) {
-    return moment(date).format('YYYY/MM/DD HH:mm:ss')
+    return DateTime.fromJSDate(date).toFormat('yyyy/MM/dd HH:mm:ss')
 }
 
 module.exports = function collectJSONS(options) {

--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -6,7 +6,7 @@ const jsonFile = require('jsonfile');
 const open = require('open');
 const path = require('path');
 const { v4: uuid } = require('uuid');
-const moment = require('moment');
+const { Duration } = require('luxon');
 const collectJSONS = require('./collect-jsons');
 
 const REPORT_STYLESHEET = 'style.css';
@@ -671,15 +671,17 @@ function generateReport(options) {
   }
 
   /**
-   * Format the duration to HH:mm:ss.SSS
+   * Formats the duration to HH:mm:ss.SSS.
    *
-   * @param {number} ns
+   * @param {number} duration a time duration usually in ns form; it can be
+   * possible to interpret the value as ms, see the option {durationInMS}.
    *
-   * @return {string}
+   * @return {string} the duration formatted as a string
    */
-  function formatDuration(ns) {
-    // `moment.utc(#)` needs ms, we now use device by 1000000 to calculate ns to ms
-    return moment.utc(durationInMS ? ns : ns / 1000000).format('HH:mm:ss.SSS');
+  function formatDuration(duration) {
+    return Duration.fromMillis(
+        durationInMS ? duration : duration / 1000000
+    ).toFormat('hh:mm:ss.SSS');
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2716,6 +2716,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "luxon": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
+      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw=="
+    },
     "macos-release": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.1.0.tgz",
@@ -2794,11 +2799,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
-    },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multiple-cucumber-html-reporter",
   "version": "3.0.0",
-  "description": "Generate beautifull cucumberjs reports for multiple instances (browsers / devices)",
+  "description": "Generate beautiful Cucumber.js reports for multiple instances (browsers / devices)",
   "keywords": [
     "cucumber",
     "html",
@@ -36,7 +36,7 @@
     "fs-extra": "^10.1.0",
     "jsonfile": "^6.1.0",
     "lodash": "^4.17.19",
-    "moment": "^2.24.0",
+    "luxon": "^3.0.4",
     "open": "^8.4.0",
     "uuid": "^9.0.0"
   },


### PR DESCRIPTION
Follow-up/part of #195 

As part of #213 there was supposed to be also a switch between `moment.js` and `luxon`. That _partially_ happen with the tests update but, due to a sinful `git rebase`, I lost track of the actual library switch.

This PR remediate that by actually switching to `luxon` as advertised in the original PR.
